### PR TITLE
move clear event and restart the rtc

### DIFF
--- a/mLRS/Common/sx-drivers/sx126x.h
+++ b/mLRS/Common/sx-drivers/sx126x.h
@@ -98,7 +98,7 @@ class Sx126xDriverBase
     void SetRx(uint32_t tmo_periodbase); // max 24 bit
     void GetPacketStatus(int8_t* RssiSync, int8_t* Snr);
     void GetRxBufferStatus(uint8_t* rxPayloadLength, uint8_t* rxStartBufferPointer);
-
+    void ClearRxEvent(void); // clear any event, if any
     // auxiliary methods
 
     void ClearDeviceError(void);


### PR DESCRIPTION
Hi Olliw, this is me jinchuuriki on rc groups
As we enter the rx function, I forgot to re start the rtc timer, so interrupt based on rtc timer (time out) can't fire anymore.
