### PR TITLE
Allow for 32 bit TIM2

### DIFF
--- a/mLRS/CommonRx/clock.h
+++ b/mLRS/CommonRx/clock.h
@@ -43,7 +43,7 @@ class ClockBase
     void init_isr_off(void);
     void enable_isr(void);
 
-    uint32_t tim_10us(void);
+    uint16_t tim_10us(void);
 };
 
 
@@ -93,7 +93,7 @@ void ClockBase::enable_isr(void)
 }
 
 
-uint32_t ClockBase::tim_10us(void)
+uint16_t ClockBase::tim_10us(void)
 {
     return CLOCK_TIMx->CNT;
 }

--- a/mLRS/CommonRx/clock.h
+++ b/mLRS/CommonRx/clock.h
@@ -62,9 +62,9 @@ void ClockBase::Reset(void)
     if (!CLOCK_PERIOD_10US) while (1) {}
 
     __disable_irq();
-    CLOCK_TIMx->CNT = 0;
-    CLOCK_TIMx->CCR1 = CLOCK_PERIOD_10US;
-    CLOCK_TIMx->CCR3 = CLOCK_SHIFT_10US;
+    uint32_t CNT = CLOCK_TIMx->CNT;
+    CLOCK_TIMx->CCR1 = CNT + CLOCK_PERIOD_10US;
+    CLOCK_TIMx->CCR3 = CNT + CLOCK_SHIFT_10US;
     LL_TIM_ClearFlag_CC1(CLOCK_TIMx); // important to do
     LL_TIM_ClearFlag_CC3(CLOCK_TIMx);
     __enable_irq();


### PR DESCRIPTION
The cause of the large bursts of lost frames on the R9 Tx side turns out to be a problem on the Rx side.  But it's not a difference with the radio chip.  It's a difference with the STM32 controller used.  The code in clock.h assumed that TIM2 has a 16 bit wide counter, but on the STM32L4, TIM2 is 32 bits wide.  So, when Reset() is called, after CNT is larger than 2^16, the timer never fires and the receiver looses sync when the next frame is lost.

Note, I was unable to test this code on other receivers so this still needs testing.  I'm guessing that passing 0xFFFFFFFF in tim_init_up is ok even for 16 bit timers and that it will be truncated, but I haven't actually checked to be sure..  This is probably also not the only way to fix this bug.

I still see many more lost frames on the Tx side than on the Rx side.  Do you see this with other transmitters?