### PR TITLE
Add reversible flashing r9*

### DIFF
--- a/tools/bin2frk.py
+++ b/tools/bin2frk.py
@@ -1,0 +1,42 @@
+import sys
+
+# Copied from https://github.com/ExpressLRS/ExpressLRS/blob/master/src/python/opentx.py#L20 GPL-3.0 and modified
+def gen_frsky(source, target):
+    with open(source, "rb") as _in:
+        with open(target, "wb+") as _out:
+            source_content = _in.read()
+            # append FrSky header (16bytes)
+            '''
+                struct FrSkyFirmwareInformation_no_pack {
+                    uint32_t fourcc; = 0x4B535246
+                    uint8_t headerVersion; = 1
+                    uint8_t firmwareVersionMajor;
+                    uint8_t firmwareVersionMinor;
+                    uint8_t firmwareVersionRevision;
+                    uint32_t size; == len(bin_content)
+                    uint8_t productFamily;
+                    uint8_t productId;
+                    uint16_t crc;
+                };
+            '''
+            print("Bin size: %u" % len(source_content))
+            _out.write(b"\x46\x52\x53\x4B") # fourcc
+            _out.write(b"\x01") # header version
+            _out.write(b"\x00\x00\x00")  # fw versions
+            size = len(source_content) + 16
+            _out.write(bytearray(
+                [size & 0xFF, size >> 8 & 0xFF, size >> 16 & 0xFF, size >> 24 & 0xFF]))
+            _out.write(b"\x00\x00") # productFamily, productId
+            _out.write(b"\x00\x00") # crc
+            _out.write(source_content)
+            _out.close()
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage ./bin2frk.py <source bin> <target bin>")
+        return
+    gen_frsky(sys.argv[1], sys.argv[2])
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
I tried myself on flashing a r9m tx module with just a opentx remote, or rather like elrs is doing.

What I found out:
- `fkr` files are bin files with a header that can be used for flashing an app (not bootloader), this works with the original and the elrs bootloader. The files have a 16byte header that is detected by opentx and the app in binary. (This pr adds a modified version of the elrs script)
- `elrs` files are bin files without a header that also can be used for flashing an app, this only works with the elrs bootloader.
- The elrs bootloader is flashed by using an app that overrides the bootloader on first startup.
- I don't know what exactly is different between the two bootloaders (appart from the elrs files), but one is opensource https://github.com/ExpressLRS/ExpressLRS/tree/master/src/bootloader/src so that one should probably be prefered.

It sadly doesn't just work to convert the mlrs hex file to a bin file and then to a frk or elrs file, I guess because the mlrs hex file also includes a bootloader (and maybe other offsets are wrong).
I think the preferred way is to use the eLRS bootloader and provide elrs files that only include the app.
I have no clue on how the use the stm32cubemx software, so it would be nice if someone could help me with building an app only bin file.