### PR TITLE
Replace commented out broken code with reason

### DIFF
--- a/mLRS/CommonRx/mavlink_interface_rx.h
+++ b/mLRS/CommonRx/mavlink_interface_rx.h
@@ -190,7 +190,7 @@ void MavlinkBase::putc(char c)
 		    // Need to recalculate CRC
 		    uint16_t crc = fmav_crc_calculate(&(buf_link_in[1]), FASTMAVLINK_HEADER_V2_LEN - 1);
 		    fmav_crc_accumulate_buf(&crc, msg_serial_out.payload, msg_serial_out.len);
-		    //uint16_t crc = fmav_crc_calculate(&(buf_link_in[1]), FASTMAVLINK_HEADER_V2_LEN - 1 + msg_serial_out.len);
+		    // Can't combine above 2 lines because we didn't modify the payload of buf_link_in
 		    fmav_crc_accumulate(&crc, msg_serial_out.crc_extra);
 		    msg_serial_out.checksum = crc;
                 }


### PR DESCRIPTION
Sorry.  I didn't mean to leave this comment in.  Replace it with a more meaningful comment.