### PR TITLE
bug fix: E5Grove, swap UART

### DIFF
--- a/mLRS/Common/hal/rx-hal-wioe5-grove-wle5jc.h
+++ b/mLRS/Common/hal/rx-hal-wioe5-grove-wle5jc.h
@@ -48,7 +48,7 @@
 #define UARTB_USE_RX
 #define UARTB_RXBUFSIZE           RX_SERIAL_RXBUFSIZE
 
-#define UARTC_USE_UART2 // debug // also UART2
+#define UARTC_USE_UART1_REMAPPED // debug // also UART2
 #define UARTC_BAUD                115200
 #define UARTC_USE_TX
 #define UARTC_TXBUFSIZE           512

--- a/mLRS/Common/hal/rx-hal-wioe5-grove-wle5jc.h
+++ b/mLRS/Common/hal/rx-hal-wioe5-grove-wle5jc.h
@@ -40,7 +40,7 @@
 // UARTC = debug port
 // UART = output port, SBus or whatever
 
-#define UARTB_USE_UART2 // serial // PA2,PA3
+#define UARTB_USE_UART1_REMAPPED // serial // PB6,PB7 Grove plug
 #define UARTB_BAUD                RX_SERIAL_BAUDRATE
 #define UARTB_USE_TX
 #define UARTB_TXBUFSIZE           RX_SERIAL_TXBUFSIZE


### PR DESCRIPTION
Hi Olli, 

Here is the bug fix for the Grove E5 module as receiver. This should fix issue #42. 
The Serial port has pointing to the wrong UART.

PS: I am the only one experimenting with this?