### PR TITLE
915 FCC Tweaks

### DIFF
--- a/mLRS/Common/common_conf.h
+++ b/mLRS/Common/common_conf.h
@@ -103,12 +103,12 @@
 #define MODE_31HZ_SEND_FRAME_TMO        15 // just needs to be larger than toa, not critical
 #define MODE_19HZ_SEND_FRAME_TMO        25 // just needs to be larger than toa, not critical
 
-#define FHSS_NUM_BAND_868_MHZ           	6 // it's a very narrow band
-#define FHSS_NUM_BAND_915_MHZ_FCC       	12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
-#define FHSS_NUM_BAND_915_MHZ_FCC_31HZ_MODE 18 // to match 2P4_31HZ
-#define FHSS_NUM_BAND_2P4_GHZ_19HZ_MODE 	12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
-#define FHSS_NUM_BAND_2P4_GHZ_31HZ_MODE 	18
-#define FHSS_NUM_BAND_2P4_GHZ           	24
+#define FHSS_NUM_BAND_868_MHZ           	    6 // it's a very narrow band
+#define FHSS_NUM_BAND_915_MHZ_FCC       	    12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
+#define FHSS_NUM_BAND_915_MHZ_FCC_31HZ_MODE     18 // to match 2P4_31HZ
+#define FHSS_NUM_BAND_2P4_GHZ_19HZ_MODE 	    12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
+#define FHSS_NUM_BAND_2P4_GHZ_31HZ_MODE 	    18
+#define FHSS_NUM_BAND_2P4_GHZ           	    24
 
 #define FRAME_TX_RX_LEN                 91 // we currently only support equal len
 

--- a/mLRS/Common/common_conf.h
+++ b/mLRS/Common/common_conf.h
@@ -103,11 +103,12 @@
 #define MODE_31HZ_SEND_FRAME_TMO        15 // just needs to be larger than toa, not critical
 #define MODE_19HZ_SEND_FRAME_TMO        25 // just needs to be larger than toa, not critical
 
-#define FHSS_NUM_BAND_868_MHZ           6 // it's a very narrow band
-#define FHSS_NUM_BAND_915_MHZ_FCC       12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
-#define FHSS_NUM_BAND_2P4_GHZ_19HZ_MODE 12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
-#define FHSS_NUM_BAND_2P4_GHZ_31HZ_MODE 18
-#define FHSS_NUM_BAND_2P4_GHZ           24
+#define FHSS_NUM_BAND_868_MHZ           	6 // it's a very narrow band
+#define FHSS_NUM_BAND_915_MHZ_FCC       	12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
+#define FHSS_NUM_BAND_915_MHZ_FCC_31HZ_MODE 18 // to match 2P4_31HZ
+#define FHSS_NUM_BAND_2P4_GHZ_19HZ_MODE 	12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
+#define FHSS_NUM_BAND_2P4_GHZ_31HZ_MODE 	18
+#define FHSS_NUM_BAND_2P4_GHZ           	24
 
 #define FRAME_TX_RX_LEN                 91 // we currently only support equal len
 

--- a/mLRS/Common/common_conf.h
+++ b/mLRS/Common/common_conf.h
@@ -105,7 +105,7 @@
 
 #define FHSS_NUM_BAND_868_MHZ           	    6 // it's a very narrow band
 #define FHSS_NUM_BAND_915_MHZ_FCC       	    12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
-#define FHSS_NUM_BAND_915_MHZ_FCC_31HZ_MODE     18 // to match 2P4_31HZ
+#define FHSS_NUM_BAND_915_MHZ_FCC_31HZ_MODE         18 // to match 2P4_31HZ
 #define FHSS_NUM_BAND_2P4_GHZ_19HZ_MODE 	    12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
 #define FHSS_NUM_BAND_2P4_GHZ_31HZ_MODE 	    18
 #define FHSS_NUM_BAND_2P4_GHZ           	    24

--- a/mLRS/Common/fhss.h
+++ b/mLRS/Common/fhss.h
@@ -111,6 +111,8 @@ const uint32_t fhss_freq_list_915_fcc[] = {
     SX12XX_FREQ_MHZ_TO_REG(913.7),
     SX12XX_FREQ_MHZ_TO_REG(914.3),
     SX12XX_FREQ_MHZ_TO_REG(914.9),
+    
+    SX12XX_FREQ_MHZ_TO_REG(915.5), //added
 
     SX12XX_FREQ_MHZ_TO_REG(916.1),
     SX12XX_FREQ_MHZ_TO_REG(916.7),
@@ -131,6 +133,8 @@ const uint32_t fhss_freq_list_915_fcc[] = {
     SX12XX_FREQ_MHZ_TO_REG(925.1),
     SX12XX_FREQ_MHZ_TO_REG(925.7),
     SX12XX_FREQ_MHZ_TO_REG(926.3),
+
+    SX12XX_FREQ_MHZ_TO_REG(926.9), //added
 };
 
 const uint8_t fhss_bind_channel_list_915_fcc[] = {

--- a/mLRS/Common/setup.h
+++ b/mLRS/Common/setup.h
@@ -388,7 +388,7 @@ void setup_configure(void)
     case SETUP_FREQUENCY_BAND_915_MHZ_FCC:
     	switch (Config.Mode) {
     	case MODE_31HZ: Config.FhssNum = FHSS_NUM_BAND_915_MHZ_FCC_31HZ_MODE; break;
-		case MODE_19HZ: Config.FhssNum = FHSS_NUM_BAND_915_MHZ_FCC; break;
+        case MODE_19HZ: Config.FhssNum = FHSS_NUM_BAND_915_MHZ_FCC; break;
         default:
             while (1) {} // must not happen, should have been resolved in setup_sanitize()
         }

--- a/mLRS/Common/setup.h
+++ b/mLRS/Common/setup.h
@@ -396,7 +396,7 @@ void setup_configure(void)
     case SETUP_FREQUENCY_BAND_868_MHZ:
         Config.FhssNum = FHSS_NUM_BAND_868_MHZ;
         break;
-    	default:
+    default:
         while (1) {} // must not happen, should have been resolved in setup_sanitize()
 	}
 

--- a/mLRS/Common/setup.h
+++ b/mLRS/Common/setup.h
@@ -386,14 +386,19 @@ void setup_configure(void)
         }
         break;
     case SETUP_FREQUENCY_BAND_915_MHZ_FCC:
-        Config.FhssNum = FHSS_NUM_BAND_915_MHZ_FCC;
+    	switch (Config.Mode) {
+    	case MODE_31HZ: Config.FhssNum = FHSS_NUM_BAND_915_MHZ_FCC_31HZ_MODE; break;
+		case MODE_19HZ: Config.FhssNum = FHSS_NUM_BAND_915_MHZ_FCC; break;
+        default:
+            while (1) {} // must not happen, should have been resolved in setup_sanitize()
+        }
         break;
     case SETUP_FREQUENCY_BAND_868_MHZ:
         Config.FhssNum = FHSS_NUM_BAND_868_MHZ;
         break;
-    default:
+    	default:
         while (1) {} // must not happen, should have been resolved in setup_sanitize()
-    }
+	}
 
     //-- More Config, may depend on above config settings
 


### PR DESCRIPTION
- Added 2 channels to 915 FCC frequency band (915.5, 926.9) bringing total to 40 channels (same as ELRS).
- Enabled 915 FCC | 31Hz to use 18 channels (same as 2.4 | 31Hz).

Tested on Wio E5 Tx+Rx.