### PR TITLE
915 FCC FHSS definition update

### DIFF
--- a/mLRS/Common/common_conf.h
+++ b/mLRS/Common/common_conf.h
@@ -103,11 +103,12 @@
 #define MODE_31HZ_SEND_FRAME_TMO        15 // just needs to be larger than toa, not critical
 #define MODE_19HZ_SEND_FRAME_TMO        25 // just needs to be larger than toa, not critical
 
-#define FHSS_NUM_BAND_868_MHZ           6 // it's a very narrow band
-#define FHSS_NUM_BAND_915_MHZ_FCC       12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
-#define FHSS_NUM_BAND_2P4_GHZ_19HZ_MODE 12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
-#define FHSS_NUM_BAND_2P4_GHZ_31HZ_MODE 18
-#define FHSS_NUM_BAND_2P4_GHZ           24
+#define FHSS_NUM_BAND_868_MHZ               6 // it's a very narrow band
+#define FHSS_NUM_BAND_915_MHZ_FCC_19HZ_MODE 12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
+#define FHSS_NUM_BAND_915_MHZ_FCC           12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
+#define FHSS_NUM_BAND_2P4_GHZ_19HZ_MODE     12 // was 24, but a cycle takes then 1.3 sec! would need long disconnect
+#define FHSS_NUM_BAND_2P4_GHZ_31HZ_MODE     18
+#define FHSS_NUM_BAND_2P4_GHZ               24
 
 #define FRAME_TX_RX_LEN                 91 // we currently only support equal len
 

--- a/mLRS/Common/setup.h
+++ b/mLRS/Common/setup.h
@@ -386,8 +386,12 @@ void setup_configure(void)
         }
         break;
     case SETUP_FREQUENCY_BAND_915_MHZ_FCC:
-        Config.FhssNum = FHSS_NUM_BAND_915_MHZ_FCC;
-        break;
+        switch (Config.Mode) {
+        case MODE_31HZ: Config.FhssNum = FHSS_NUM_BAND_915_MHZ_FCC; break;
+        case MODE_19HZ: Config.FhssNum = FHSS_NUM_BAND_915_MHZ_FCC_19HZ_MODE; break;
+        default:
+            while (1) {} // must not happen, should have been resolved in setup_sanitize()
+        }
     case SETUP_FREQUENCY_BAND_868_MHZ:
         Config.FhssNum = FHSS_NUM_BAND_868_MHZ;
         break;


### PR DESCRIPTION
Added 'FHSS_NUM_BAND_915_MHZ_FCC_19HZ_MODE' definition and switch statement to handle new definition.  No changes to the number of hop channels.

Built successfully for Wio E5.