### PR TITLE
rx-E5-mini LED swap similar to tx-E5-mini

### DIFF
--- a/mLRS/Common/hal/rx-hal-wioe5-mini-wle5jc.h
+++ b/mLRS/Common/hal/rx-hal-wioe5-mini-wle5jc.h
@@ -6,6 +6,7 @@
 //*******************************************************
 // hal
 //*******************************************************
+// 24.Feb.2023: LED pin changed! pin for artificial GND (PA0)! consistent with tx-wioe5
 
 //-------------------------------------------------------
 // RX Seeedstudio Wio-E5 Mini Dev board STM32WLE5JC, https://wiki.seeedstudio.com/LoRa_E5_mini
@@ -172,13 +173,20 @@ bool button_pressed(void)
 
 //-- LEDs
 
-#define LED_GREEN                 IO_PB4
+#define LED_GREEN                 IO_PA15
 #define LED_RED                   IO_PB5
 
 void leds_init(void)
 {
     gpio_init(LED_GREEN, IO_MODE_OUTPUT_PP_LOW, IO_SPEED_DEFAULT);
     gpio_init(LED_RED, IO_MODE_OUTPUT_PP_HIGH, IO_SPEED_DEFAULT);
+
+    // pin IO_PB15 must be floating, is used as artificial pad for green LED!
+    gpio_init(IO_PB15, IO_MODE_Z, IO_SPEED_DEFAULT);
+
+    // artificial GND for R+Diode mod, ONLY temporary
+    // this is dirty! we do it here in leds_init() to ensure it is called
+    gpio_init(IO_PA0, IO_MODE_OUTPUT_PP_LOW, IO_SPEED_DEFAULT);
 }
 
 void led_green_off(void) { gpio_low(LED_GREEN); }


### PR DESCRIPTION
Hi Olli, 

I fell in love with your _new_ idea of the LED assembly for the tx-E5-mini. 
Mainly for debugging purposes I have to flash a "tx-E5-mini" with rx-firmware. The presence of a green LED or a real bind-button can help a lot (The rx-Gove-E5 is very limited). 
To be consistent (and interchangeable for debugging) I want to do the same trick here. 

Hopefully this don't break other existing assemblies. 
Let me know what you think.

Regards, Sascha
