### PR TITLE
WiFi Channel Parameter

### DIFF
--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -73,7 +73,7 @@ int baudrate = 57600;
 
 // WiFi channel
 // comment out for default setting
-#define WIFI_CHANNEL  13 // Use 13 (2461-2483 MHz) since it has least overlap with mLRS 2.4 freqs, default is 1
+int WIFI_CHANNEL = 13; // Use 13 (2461-2483 MHz) since it has least overlap with 2.4 freqs
 
 
 // serial port usage (only effective for a generic board)

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -145,7 +145,7 @@ void setup()
     // AP mode
     //WiFi.mode(WIFI_AP); // seems not to be needed, done by WiFi.softAP()?
     WiFi.softAPConfig(ip, ip, netmask);
-    WiFi.softAP(ssid.c_str(), (password.length()) ? password.c_str() : NULL);
+    WiFi.softAP(ssid.c_str(), (password.length()) ? password.c_str() : NULL, WIFI_CHANNEL);
 
     DBG_PRINT("ap ip address: ");
     DBG_PRINTLN(WiFi.softAPIP()); // comes out as 192.168.4.1

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -71,6 +71,10 @@ int baudrate = 57600;
 // comment out for default setting
 #define WIFI_POWER  WIFI_POWER_2dBm // WIFI_POWER_MINUS_1dBm is the lowest possible, WIFI_POWER_19_5dBm is the max
 
+// WiFi channel
+// comment out for default setting
+#define WIFI_CHANNEL  13 // Use 13 (2461-2483 MHz) since it has least overlap with mLRS 2.4 freqs, default is 1
+
 
 // serial port usage (only effective for a generic board)
 // comment all for default behavior, which is using only Serial port

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -73,7 +73,7 @@ int baudrate = 57600;
 
 // WiFi channel
 // comment out for default setting
-int WIFI_CHANNEL = 13; // Use 13 (2461-2483 MHz) since it has least overlap with 2.4 freqs
+int wifi_channel = 13; // Use 13 (2461-2483 MHz) since it has least overlap with 2.4 freqs
 
 
 // serial port usage (only effective for a generic board)
@@ -145,7 +145,7 @@ void setup()
     // AP mode
     //WiFi.mode(WIFI_AP); // seems not to be needed, done by WiFi.softAP()?
     WiFi.softAPConfig(ip, ip, netmask);
-    WiFi.softAP(ssid.c_str(), (password.length()) ? password.c_str() : NULL, WIFI_CHANNEL);
+    WiFi.softAP(ssid.c_str(), (password.length()) ? password.c_str() : NULL, wifi_channel);
 
     DBG_PRINT("ap ip address: ");
     DBG_PRINTLN(WiFi.softAPIP()); // comes out as 192.168.4.1


### PR DESCRIPTION
Add a define for WiFi channel, set to 13 which should overlap least with mLRS freq list and home WiFi.

Tested on my ESP32.