### PR TITLE
Image calibration

### DIFF
--- a/mLRS/Common/sx-drivers/sx126x_driver.h
+++ b/mLRS/Common/sx-drivers/sx126x_driver.h
@@ -165,14 +165,14 @@ class Sx126xDriverCommon : public Sx126xDriverBase
         //Default for SX1261/2 is 902 to 902 MHz
         //Default for SX1268 is 470 to 510 MHz
         switch (Setup.FrequencyBand) {
-			case SETUP_FREQUENCY_BAND_915_MHZ_FCC: CalibrateImage(SX126X_CAL_IMG_902_MHZ_1, SX126X_CAL_IMG_902_MHZ_2); break;
-			case SETUP_FREQUENCY_BAND_868_MHZ: CalibrateImage(SX126X_CAL_IMG_863_MHZ_1, SX126X_CAL_IMG_863_MHZ_2); break;
-			case SETUP_FREQUENCY_BAND_433_MHZ: CalibrateImage(SX126X_CAL_IMG_430_MHZ_1, SX126X_CAL_IMG_430_MHZ_2); break;
-			case SETUP_FREQUENCY_BAND_70_CM_HAM: CalibrateImage(SX126X_CAL_IMG_430_MHZ_1, SX126X_CAL_IMG_430_MHZ_2); break;
-			default:
-				while (1) {}  // protection
+            case SETUP_FREQUENCY_BAND_915_MHZ_FCC: CalibrateImage(SX126X_CAL_IMG_902_MHZ_1, SX126X_CAL_IMG_902_MHZ_2); break;
+            case SETUP_FREQUENCY_BAND_868_MHZ: CalibrateImage(SX126X_CAL_IMG_863_MHZ_1, SX126X_CAL_IMG_863_MHZ_2); break;
+            case SETUP_FREQUENCY_BAND_433_MHZ: CalibrateImage(SX126X_CAL_IMG_430_MHZ_1, SX126X_CAL_IMG_430_MHZ_2); break;
+            case SETUP_FREQUENCY_BAND_70_CM_HAM: CalibrateImage(SX126X_CAL_IMG_430_MHZ_1, SX126X_CAL_IMG_430_MHZ_2); break;
+            default:
+            while (1) {}  // protection
         }
-        
+
         // set DIO2 as RF control switching
         // check the RF module if antenna switching is internally connected to DIO2
         // E22-900M rf switching controlled by IO pin of MCU

--- a/mLRS/Common/sx-drivers/sx126x_driver.h
+++ b/mLRS/Common/sx-drivers/sx126x_driver.h
@@ -170,7 +170,7 @@ class Sx126xDriverCommon : public Sx126xDriverBase
             case SETUP_FREQUENCY_BAND_433_MHZ: CalibrateImage(SX126X_CAL_IMG_430_MHZ_1, SX126X_CAL_IMG_430_MHZ_2); break;
             case SETUP_FREQUENCY_BAND_70_CM_HAM: CalibrateImage(SX126X_CAL_IMG_430_MHZ_1, SX126X_CAL_IMG_430_MHZ_2); break;
             default:
-            while (1) {}  // protection
+                while (1) {}  // protection
         }
 
         // set DIO2 as RF control switching

--- a/mLRS/Common/sx-drivers/sx126x_driver.h
+++ b/mLRS/Common/sx-drivers/sx126x_driver.h
@@ -160,6 +160,19 @@ class Sx126xDriverCommon : public Sx126xDriverBase
         if (osc_configuration != SX12xx_OSCILLATOR_CONFIG_CRYSTAL) {
             SetDio3AsTcxoControl(osc_configuration, 250); // set output to 1.6V-3.3V, ask specification of TCXO to maker board
         }
+
+        //Image Calibration per datasheet 9.2.1
+        //Default for SX1261/2 is 902 to 902 MHz
+        //Default for SX1268 is 470 to 510 MHz
+        switch (Setup.FrequencyBand) {
+			case SETUP_FREQUENCY_BAND_915_MHZ_FCC: CalibrateImage(SX126X_CAL_IMG_902_MHZ_1, SX126X_CAL_IMG_902_MHZ_2); break;
+			case SETUP_FREQUENCY_BAND_868_MHZ: CalibrateImage(SX126X_CAL_IMG_863_MHZ_1, SX126X_CAL_IMG_863_MHZ_2); break;
+			case SETUP_FREQUENCY_BAND_433_MHZ: CalibrateImage(SX126X_CAL_IMG_430_MHZ_1, SX126X_CAL_IMG_430_MHZ_2); break;
+			case SETUP_FREQUENCY_BAND_70_CM_HAM: CalibrateImage(SX126X_CAL_IMG_430_MHZ_1, SX126X_CAL_IMG_430_MHZ_2); break;
+			default:
+				while (1) {}  // protection
+        }
+        
         // set DIO2 as RF control switching
         // check the RF module if antenna switching is internally connected to DIO2
         // E22-900M rf switching controlled by IO pin of MCU


### PR DESCRIPTION
Added based on datasheet 9.2.1.  Supposed to help Rx performance - saw no real change in RSSI on the bench with and without.