### PR TITLE
Disable mbridge serial port receiver when transmitter is enabled

### DIFF
--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -193,7 +193,7 @@ void tPin5BridgeBase::pin5_tx_enable(bool enable_flag)
 {
   if (enable_flag) {
       uart_rx_enableisr(DISABLE);
-      UART_UARTx->CR1 &= ~USART_CR1_RE; // turn off receiver
+      LL_USART_DisableDirectionRx(UART_UARTx);
 
 #if defined JRPIN5_TX_OE
       JRPIN5_TX_OE_ENABLED;
@@ -210,7 +210,7 @@ void tPin5BridgeBase::pin5_tx_enable(bool enable_flag)
       LL_USART_SetTransferDirection(UART_UARTx, LL_USART_DIRECTION_RX);
 #endif
 
-      UART_UARTx->CR1 |= USART_CR1_RE; // turn on receiver
+      LL_USART_EnableDirectionRx(UART_UARTx);
       uart_rx_enableisr(ENABLE);
   }
 }

--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -193,6 +193,7 @@ void tPin5BridgeBase::pin5_tx_enable(bool enable_flag)
 {
   if (enable_flag) {
       uart_rx_enableisr(DISABLE);
+      UART_UARTx->CR1 &= ~USART_CR1_RE; // turn off receiver
 
 #if defined JRPIN5_TX_OE
       JRPIN5_TX_OE_ENABLED;
@@ -209,6 +210,7 @@ void tPin5BridgeBase::pin5_tx_enable(bool enable_flag)
       LL_USART_SetTransferDirection(UART_UARTx, LL_USART_DIRECTION_RX);
 #endif
 
+      UART_UARTx->CR1 |= USART_CR1_RE; // turn on receiver
       uart_rx_enableisr(ENABLE);
   }
 }


### PR DESCRIPTION
This eliminates the spurious received characters I was seeing in my debug output on my R9M
With this change I'm no longer seeing lost messages when connecting QGC via bluetooth routed from mbridge with openTX.