### PR TITLE
50 Hz baud rate increase

### DIFF
--- a/mLRS/CommonRx/mavlink_interface_rx.h
+++ b/mLRS/CommonRx/mavlink_interface_rx.h
@@ -202,7 +202,7 @@ void MavlinkBase::putc(char c)
 #if MAVLINK_OPT_FAKE_PARAMFTP > 1
         bool force_param_list = true;
         switch (Config.Mode) {
-        case MODE_50HZ: force_param_list = (Config.SerialBaudrate > 57600); break; // 57600 bps and lower is ok for mftp
+        case MODE_50HZ: force_param_list = (Config.SerialBaudrate > 115200); break; // 115200 bps and lower is ok for mftp
         case MODE_31HZ: force_param_list = (Config.SerialBaudrate > 57600); break; // 57600 bps and lower is ok for mftp
         case MODE_19HZ: force_param_list = (Config.SerialBaudrate > 38400); break; // 38400 bps and lower is ok for mftp
         }


### PR DESCRIPTION
I tried this out on Arduplane 4.3.5 and 4.4.0-Beta and this gave a nice increase in speed when downloading parameters over MAVFTP on 50 Hz.

- 115200 baud = 11,520 bytes / sec
- Ardu limits to 30%
- 11,520 * 0.3 = 3,456 bytes / sec
- 50 Hz downlink is 4,100 bytes / sec