### PR TITLE
Remove CRSF RSSI Inversion

### DIFF
--- a/mLRS/Common/common_types.cpp
+++ b/mLRS/Common/common_types.cpp
@@ -168,7 +168,7 @@ uint8_t crsf_cvt_fps(uint8_t mode)
 uint8_t crsf_cvt_rssi(int8_t rssi_i8)
 {
     if (rssi_i8 == RSSI_INVALID) return 0;
-    return -rssi_i8;
+    return rssi_i8;
 }
 
 

--- a/mLRS/Common/common_types.cpp
+++ b/mLRS/Common/common_types.cpp
@@ -168,7 +168,7 @@ uint8_t crsf_cvt_fps(uint8_t mode)
 uint8_t crsf_cvt_rssi(int8_t rssi_i8)
 {
     if (rssi_i8 == RSSI_INVALID) return 0;
-    return rssi_i8;
+    return -rssi_i8;
 }
 
 

--- a/mLRS/CommonTx/crsf_interface_tx.h
+++ b/mLRS/CommonTx/crsf_interface_tx.h
@@ -814,7 +814,7 @@ void crsf_send_LinkStatistics(void)
 {
 tCrsfLinkStatistics clstats;
 
-    clstats.uplink_rssi1 = crsf_cvt_rssi(stats.received_rssi);              // OpenTX -> "1RSS"
+    clstats.uplink_rssi1 = stats.received_rssi;                             // OpenTX -> "1RSS"
     clstats.uplink_rssi2 = 0; // we don't know it                           // OpenTX -> "2RSS"
     clstats.uplink_LQ = stats.received_LQ; // this sets main rssi in OpenTx, 0 = resets main rssi   // OpenTx -> "RQly"
     clstats.uplink_snr = 0; // we don't know it                             // OpenTx -> "RSNR"
@@ -822,7 +822,7 @@ tCrsfLinkStatistics clstats;
     clstats.mode = crsf_cvt_mode(Config.Mode);                              // OpenTx -> "RFMD"
     clstats.uplink_transmit_power = crsf_cvt_power(sx.RfPower_dbm());       // OpenTx -> "TPw2"   // ?????? uplink but "T" ??
 
-    clstats.downlink_rssi = crsf_cvt_rssi(stats.GetLastRssi());             // OpenTx -> "TRSS"
+    clstats.downlink_rssi = stats.GetLastRssi();                            // OpenTx -> "TRSS"
     clstats.downlink_LQ = txstats.GetLQ();                                  // OpenTx -> "TQly"
     clstats.downlink_snr = stats.GetLastSnr();                              // OpenTx -> "TSNR"
     crsf.SendLinkStatistics(&clstats);


### PR DESCRIPTION
EdgeTx handles this fine and shows negative RSSI - same values the driver provides.

Close to plane (-22 dB):

![image](https://user-images.githubusercontent.com/41841496/235981630-d231e28f-b38c-4ae8-afa8-7ff2fe858f39.png)

Further from plane (-38 dB):

![image](https://user-images.githubusercontent.com/41841496/235981730-c5413e6f-e798-42e9-918f-87dd3d358f62.png)

