### PR TITLE
JR5 pin swap (mostly for E77 easysolder)

### DIFF
--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -145,7 +145,7 @@ void tPin5BridgeBase::Init(void)
 #endif
 
 // used to swap the Tx and Rx pins for E77 easysolder as Tx
-#if defined JRPIN5_RX_TX_PIN_SWAP
+#if defined JRPIN5_RX_TX_INVERT_SWAP_INTERNAL
     LL_USART_Disable(UART_UARTx);
     LL_USART_SetTXRXSwap(UART_UARTx, LL_USART_TXRX_SWAPPED);
     LL_USART_Enable(UART_UARTx);

--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -140,7 +140,8 @@ void tPin5BridgeBase::Init(void)
     LL_USART_SetRXPinLevel(UART_UARTx, LL_USART_RXPIN_LEVEL_INVERTED);
     LL_USART_SetTXRXSwap(UART_UARTx, LL_USART_TXRX_SWAPPED);
     LL_USART_Enable(UART_UARTx);
-    //gpio_init_af(UART_RX_IO, IO_MODE_INPUT_PD, UART_IO_AF, IO_SPEED_VERYFAST);  Not needed?
+    gpio_init_af(UART_TX_IO, IO_MODE_INPUT_PD, UART_IO_AF, IO_SPEED_VERYFAST);  // tx pin is now an input after swap
+    gpio_init_af(UART_RX_IO, IO_MODE_OUTPUT_ALTERNATE_PP, UART_IO_AF, IO_SPEED_VERYFAST);  // rx pin is now an output after swap
 #endif
 #if defined JRPIN5_FULL_INTERNAL
     LL_USART_Disable(UART_UARTx);

--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -133,6 +133,15 @@ void tPin5BridgeBase::Init(void)
     LL_USART_Enable(UART_UARTx);
     gpio_init_af(UART_RX_IO, IO_MODE_INPUT_PD, UART_IO_AF, IO_SPEED_VERYFAST);
 #endif
+// swaps the Tx and Rx pins for E77 easysolder as Tx
+#if defined JRPIN5_RX_TX_INVERT_SWAP_INTERNAL
+    LL_USART_Disable(UART_UARTx);
+    LL_USART_SetTXPinLevel(UART_UARTx, LL_USART_TXPIN_LEVEL_INVERTED);
+    LL_USART_SetRXPinLevel(UART_UARTx, LL_USART_RXPIN_LEVEL_INVERTED);
+    LL_USART_SetTXRXSwap(UART_UARTx, LL_USART_TXRX_SWAPPED);
+    LL_USART_Enable(UART_UARTx);
+    gpio_init_af(UART_RX_IO, IO_MODE_INPUT_PD, UART_IO_AF, IO_SPEED_VERYFAST);
+#endif
 #if defined JRPIN5_FULL_INTERNAL
     LL_USART_Disable(UART_UARTx);
     LL_USART_ConfigHalfDuplexMode(UART_UARTx);
@@ -142,13 +151,6 @@ void tPin5BridgeBase::Init(void)
     LL_USART_SetTransferDirection(UART_UARTx, LL_USART_DIRECTION_NONE);
     LL_USART_Enable(UART_UARTx);
     gpio_init_af(UART_RX_IO, IO_MODE_INPUT_PD, UART_IO_AF, IO_SPEED_VERYFAST);
-#endif
-
-// used to swap the Tx and Rx pins for E77 easysolder as Tx
-#if defined JRPIN5_RX_TX_INVERT_SWAP_INTERNAL
-    LL_USART_Disable(UART_UARTx);
-    LL_USART_SetTXRXSwap(UART_UARTx, LL_USART_TXRX_SWAPPED);
-    LL_USART_Enable(UART_UARTx);
 #endif
 
 

--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -154,7 +154,6 @@ void tPin5BridgeBase::Init(void)
     gpio_init_af(UART_RX_IO, IO_MODE_INPUT_PD, UART_IO_AF, IO_SPEED_VERYFAST);
 #endif
 
-
     pin5_tx_enable(false);
 
     state = STATE_IDLE;

--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -125,7 +125,7 @@ void tPin5BridgeBase::Init(void)
 
     uart_init_isroff();
 
-// internal peripheral inverter method, G491, WLE5, needs a diode from Tx to Rx
+// internal peripheral inverter method, G4, WLE5, needs a diode from Tx to Rx
 #if defined JRPIN5_RX_TX_INVERT_INTERNAL
     LL_USART_Disable(UART_UARTx);
     LL_USART_SetTXPinLevel(UART_UARTx, LL_USART_TXPIN_LEVEL_INVERTED);
@@ -133,7 +133,7 @@ void tPin5BridgeBase::Init(void)
     LL_USART_Enable(UART_UARTx);
     gpio_init_af(UART_RX_IO, IO_MODE_INPUT_PD, UART_IO_AF, IO_SPEED_VERYFAST);
 #endif
-// internal peripheral inverter method with TxRx swap, G491, WLE5, needs a diode from Rx to Tx
+// internal peripheral inverter method with TxRx swap, G4, WLE5, needs a diode from Rx to Tx
 #if defined JRPIN5_RX_TX_INVERT_SWAP_INTERNAL
     LL_USART_Disable(UART_UARTx);
     LL_USART_SetTXPinLevel(UART_UARTx, LL_USART_TXPIN_LEVEL_INVERTED);

--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -144,6 +144,14 @@ void tPin5BridgeBase::Init(void)
     gpio_init_af(UART_RX_IO, IO_MODE_INPUT_PD, UART_IO_AF, IO_SPEED_VERYFAST);
 #endif
 
+// used to swap the Tx and Rx pins for E77 easysolder as Tx
+#if defined JRPIN5_RX_TX_PIN_SWAP
+    LL_USART_Disable(UART_UARTx);
+    LL_USART_SetTXRXSwap(UART_UARTx, LL_USART_TXRX_SWAPPED);
+    LL_USART_Enable(UART_UARTx);
+#endif
+
+
     pin5_tx_enable(false);
 
     state = STATE_IDLE;

--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -133,14 +133,14 @@ void tPin5BridgeBase::Init(void)
     LL_USART_Enable(UART_UARTx);
     gpio_init_af(UART_RX_IO, IO_MODE_INPUT_PD, UART_IO_AF, IO_SPEED_VERYFAST);
 #endif
-// swaps the Tx and Rx pins for E77 easysolder as Tx
+// internal peripheral inverter method with TxRx swap, G491, WLE5, needs a diode from Rx to Tx
 #if defined JRPIN5_RX_TX_INVERT_SWAP_INTERNAL
     LL_USART_Disable(UART_UARTx);
     LL_USART_SetTXPinLevel(UART_UARTx, LL_USART_TXPIN_LEVEL_INVERTED);
     LL_USART_SetRXPinLevel(UART_UARTx, LL_USART_RXPIN_LEVEL_INVERTED);
     LL_USART_SetTXRXSwap(UART_UARTx, LL_USART_TXRX_SWAPPED);
     LL_USART_Enable(UART_UARTx);
-    gpio_init_af(UART_RX_IO, IO_MODE_INPUT_PD, UART_IO_AF, IO_SPEED_VERYFAST);
+    //gpio_init_af(UART_RX_IO, IO_MODE_INPUT_PD, UART_IO_AF, IO_SPEED_VERYFAST);  Not needed?
 #endif
 #if defined JRPIN5_FULL_INTERNAL
     LL_USART_Disable(UART_UARTx);


### PR DESCRIPTION
New define is 'JRPIN5_RX_TX_INVERT_SWAP_INTERNAL'

Added to the Hal after '#define JRPIN5_RX_TX_INVERT_INTERNAL'

Tested and working on E77 using 'S' pin for JR pin 5.  