### PR TITLE
Preliminary, not fully tested approach to building images for ExpressLRS bootloader

### DIFF
--- a/mLRS/Common/hal/rx-hal-R9M-868-f103c8.h
+++ b/mLRS/Common/hal/rx-hal-R9M-868-f103c8.h
@@ -23,7 +23,7 @@
 #define SYSTICK_TIMESTEP          1000
 #define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
 
-#define EE_START_PAGE             60 // 64 kB flash, 1 kB page
+#define EE_START_PAGE             124 // 128 kB flash, 1 kB page
 
 #define MICROS_TIMx               TIM3
 

--- a/mLRS/Common/hal/tx-hal-R9M-868-f103c8.h
+++ b/mLRS/Common/hal/tx-hal-R9M-868-f103c8.h
@@ -29,7 +29,7 @@
 #define SYSTICK_TIMESTEP          1000
 #define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
 
-#define EE_START_PAGE             60 // 64 kB flash, 1 kB page
+#define EE_START_PAGE             124 // 128 kB flash, 1 kB page
 
 #define MICROS_TIMx               TIM3
 

--- a/mLRS/rx-R9M-f103c8/Core/Src/main.cpp
+++ b/mLRS/rx-R9M-f103c8/Core/Src/main.cpp
@@ -53,6 +53,10 @@ int main_main();
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
+#ifdef MLRS_FEATURE_ELRS_BOOTLOADER
+// The presence of this symbol indicates to linker script that ELRS bootloader will be used
+char mlrs_elrs_bootloader;
+#endif
 
 /* USER CODE END 0 */
 
@@ -63,6 +67,9 @@ int main_main();
 int main(void)
 {
   /* USER CODE BEGIN 1 */
+#ifdef MLRS_FEATURE_ELRS_BOOTLOADER
+  HAL_RCC_DeInit(); // Need to unconfigure clock/PLL since ELRS uses HSI clock
+#endif
 
   /* USER CODE END 1 */
 

--- a/mLRS/rx-R9M-f103c8/STM32F103C8TX_FLASH.ld
+++ b/mLRS/rx-R9M-f103c8/STM32F103C8TX_FLASH.ld
@@ -45,7 +45,7 @@ _Min_Stack_Size = 0x400 ; /* required amount of stack */
 MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 20K
-  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 64K
+  FLASH    (rx)    : ORIGIN = DEFINED(mlrs_elrs_bootloader) ? 0x8004000 : 0x8000000,   LENGTH = DEFINED(mlrs_elrs_bootloader) ? 128K-0x4000 : 128K
 }
 
 /* Sections */

--- a/mLRS/rx-R9MM-f103rb/Core/Src/main.cpp
+++ b/mLRS/rx-R9MM-f103rb/Core/Src/main.cpp
@@ -54,6 +54,10 @@ int main_main();
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
+#ifdef MLRS_FEATURE_ELRS_BOOTLOADER
+// The presence of this symbol indicates to linker script that ELRS bootloader will be used
+char mlrs_elrs_bootloader;
+#endif
 
 /* USER CODE END 0 */
 
@@ -64,6 +68,9 @@ int main_main();
 int main(void)
 {
   /* USER CODE BEGIN 1 */
+#ifdef MLRS_FEATURE_ELRS_BOOTLOADER
+  HAL_RCC_DeInit(); // Need to unconfigure clock/PLL since ELRS uses HSI clock
+#endif
 
   /* USER CODE END 1 */
 

--- a/mLRS/rx-R9MM-f103rb/STM32F103RBHX_FLASH.ld
+++ b/mLRS/rx-R9MM-f103rb/STM32F103RBHX_FLASH.ld
@@ -46,7 +46,7 @@ _Min_Stack_Size = 0x400 ; /* required amount of stack */
 MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 20K
-  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 128K
+  FLASH    (rx)    : ORIGIN = DEFINED(mlrs_elrs_bootloader) ? 0x8008000 : 0x8000000,   LENGTH = DEFINED(mlrs_elrs_bootloader) ? 128K-0x8000 : 128K
 }
 
 /* Sections */

--- a/mLRS/rx-R9MX-l433cb/Core/Src/main.cpp
+++ b/mLRS/rx-R9MX-l433cb/Core/Src/main.cpp
@@ -53,6 +53,10 @@ int main_main();
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
+#ifdef MLRS_FEATURE_ELRS_BOOTLOADER
+// The presence of this symbol indicates to linker script that ELRS bootloader will be used
+char mlrs_elrs_bootloader;
+#endif
 
 /* USER CODE END 0 */
 
@@ -63,6 +67,9 @@ int main_main();
 int main(void)
 {
   /* USER CODE BEGIN 1 */
+#ifdef MLRS_FEATURE_ELRS_BOOTLOADER
+  HAL_RCC_DeInit(); // Need to unconfigure clock/PLL since ELRS uses HSI clock
+#endif
 
   /* USER CODE END 1 */
 

--- a/mLRS/rx-R9MX-l433cb/STM32L433CBYX_FLASH.ld
+++ b/mLRS/rx-R9MX-l433cb/STM32L433CBYX_FLASH.ld
@@ -47,7 +47,7 @@ MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 64K
   RAM2    (xrw)    : ORIGIN = 0x10000000,   LENGTH = 16K
-  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 128K
+  FLASH    (rx)    : ORIGIN = DEFINED(mlrs_elrs_bootloader) ? 0x8008000 : 0x8000000,   LENGTH = DEFINED(mlrs_elrs_bootloader) ? 128K-0x8000 : 128K
 }
 
 /* Sections */

--- a/mLRS/tx-R9M-f103c8/Core/Src/main.cpp
+++ b/mLRS/tx-R9M-f103c8/Core/Src/main.cpp
@@ -56,6 +56,9 @@ int main_main();
 /* USER CODE BEGIN 0 */
 
 /* USER CODE END 0 */
+#ifdef MLRS_USE_BOOTLOADER
+char mlrs_use_bootloader=1; // Indicate to linker script that bootloader will be used
+#endif
 
 /**
   * @brief  The application entry point.
@@ -70,6 +73,9 @@ int main(void)
   /* MCU Configuration--------------------------------------------------------*/
 
   /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
+#ifdef MLRS_USE_BOOTLOADER
+  HAL_RCC_DeInit();
+#endif
   HAL_Init();
 
   /* USER CODE BEGIN Init */

--- a/mLRS/tx-R9M-f103c8/Core/Src/main.cpp
+++ b/mLRS/tx-R9M-f103c8/Core/Src/main.cpp
@@ -54,11 +54,12 @@ int main_main();
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
+#ifdef MLRS_FEATURE_ELRS_BOOTLOADER
+// The presence of this symbol indicates to linker script that ELRS bootloader will be used
+char mlrs_elrs_bootloader;
+#endif
 
 /* USER CODE END 0 */
-#ifdef MLRS_USE_BOOTLOADER
-char mlrs_use_bootloader=1; // Indicate to linker script that bootloader will be used
-#endif
 
 /**
   * @brief  The application entry point.
@@ -67,15 +68,15 @@ char mlrs_use_bootloader=1; // Indicate to linker script that bootloader will be
 int main(void)
 {
   /* USER CODE BEGIN 1 */
+#ifdef MLRS_FEATURE_ELRS_BOOTLOADER
+  HAL_RCC_DeInit(); // Need to unconfigure clock/PLL since ELRS uses HSI clock
+#endif
 
   /* USER CODE END 1 */
 
   /* MCU Configuration--------------------------------------------------------*/
 
   /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
-#ifdef MLRS_USE_BOOTLOADER
-  HAL_RCC_DeInit();
-#endif
   HAL_Init();
 
   /* USER CODE BEGIN Init */

--- a/mLRS/tx-R9M-f103c8/STM32F103C8TX_FLASH.ld
+++ b/mLRS/tx-R9M-f103c8/STM32F103C8TX_FLASH.ld
@@ -46,7 +46,7 @@ _Min_Stack_Size = 0x400 ; /* required amount of stack */
 MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 20K
-  FLASH    (rx)    : ORIGIN = DEFINED(mlrs_use_bootloader) ? 0x8004000 : 0x8000000,   LENGTH = 128K-0x4000
+  FLASH    (rx)    : ORIGIN = DEFINED(mlrs_elrs_bootloader) ? 0x8004000 : 0x8000000,   LENGTH = DEFINED(mlrs_elrs_bootloader) ? 128K-0x4000 : 128K
 }
 
 /* Sections */

--- a/mLRS/tx-R9M-f103c8/STM32F103C8TX_FLASH.ld
+++ b/mLRS/tx-R9M-f103c8/STM32F103C8TX_FLASH.ld
@@ -46,7 +46,7 @@ _Min_Stack_Size = 0x400 ; /* required amount of stack */
 MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 20K
-  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 64K
+  FLASH    (rx)    : ORIGIN = DEFINED(mlrs_use_bootloader) ? 0x8004000 : 0x8000000,   LENGTH = 128K-0x4000
 }
 
 /* Sections */

--- a/mLRS/tx-R9MX-l433cb/Core/Src/main.cpp
+++ b/mLRS/tx-R9MX-l433cb/Core/Src/main.cpp
@@ -53,6 +53,10 @@ int main_main();
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
+#ifdef MLRS_FEATURE_ELRS_BOOTLOADER
+// The presence of this symbol indicates to linker script that ELRS bootloader will be used
+char mlrs_elrs_bootloader;
+#endif
 
 /* USER CODE END 0 */
 
@@ -63,6 +67,9 @@ int main_main();
 int main(void)
 {
   /* USER CODE BEGIN 1 */
+#ifdef MLRS_FEATURE_ELRS_BOOTLOADER
+  HAL_RCC_DeInit(); // Need to unconfigure clock/PLL since ELRS uses HSI clock
+#endif
 
   /* USER CODE END 1 */
 

--- a/mLRS/tx-R9MX-l433cb/STM32L433CBUX_FLASH.ld
+++ b/mLRS/tx-R9MX-l433cb/STM32L433CBUX_FLASH.ld
@@ -47,7 +47,7 @@ MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 64K
   RAM2    (xrw)    : ORIGIN = 0x10000000,   LENGTH = 16K
-  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 128K
+  FLASH    (rx)    : ORIGIN = DEFINED(mlrs_elrs_bootloader) ? 0x8008000 : 0x8000000,   LENGTH = DEFINED(mlrs_elrs_bootloader) ? 128K-0x8000 : 128K
 }
 
 /* Sections */

--- a/tools/run_make_firmwares3.py
+++ b/tools/run_make_firmwares3.py
@@ -880,17 +880,20 @@ TLIST = [
         'target' : 'rx-R9M-f103c8',                     'target_D' : 'RX_R9M_868_F103C8',
         'extra_D_list' : [], 'appendix' : '' 
     },{ 
+        'target' : 'rx-R9M-f103c8',                     'target_D' : 'RX_R9M_868_F103C8',
+        'extra_D_list' : ['MLRS_FEATURE_ELRS_BOOTLOADER'], 'appendix' : '-elrs-bl' 
+    },{ 
         'target' : 'rx-R9MM-f103rb',                    'target_D' : 'RX_R9MM_868_F103RB',
         'extra_D_list' : [], 'appendix' : '' 
     },{ 
         'target' : 'rx-R9MM-f103rb',                    'target_D' : 'RX_R9MM_868_F103RB',
-        'extra_D_list' : ['MLRS_FEATURE_ELRS_BOOTLOADER'], 'appendix' : '-for-elrs-bl' 
+        'extra_D_list' : ['MLRS_FEATURE_ELRS_BOOTLOADER'], 'appendix' : '-elrs-bl' 
     },{ 
         'target' : 'rx-R9MX-l433cb',                    'target_D' : 'RX_R9MX_868_L433CB',
         'extra_D_list' : [], 'appendix' : '' 
     },{ 
         'target' : 'rx-R9MX-l433cb',                    'target_D' : 'RX_R9MX_868_L433CB',
-        'extra_D_list' : ['MLRS_FEATURE_ELRS_BOOTLOADER'], 'appendix' : '-for-elrs-bl' 
+        'extra_D_list' : ['MLRS_FEATURE_ELRS_BOOTLOADER'], 'appendix' : '-elrs-bl' 
     },{ 
         'target' : 'rx-Wio-E5-Grove-wle5jc',            'target_D' : 'RX_WIO_E5_GROVE_WLE5JC',
         'extra_D_list' : [], 'appendix' : '' 
@@ -951,10 +954,13 @@ TLIST = [
         'extra_D_list' : [], 'appendix' : '' 
     },{ 
         'target' : 'tx-R9M-f103c8',                     'target_D' : 'TX_R9M_868_F103C8',
-        'extra_D_list' : ['MLRS_FEATURE_ELRS_BOOTLOADER'], 'appendix' : '-for-elrs-bl' 
+        'extra_D_list' : ['MLRS_FEATURE_ELRS_BOOTLOADER'], 'appendix' : '-elrs-bl' 
     },{ 
         'target' : 'tx-R9MX-l433cb',                    'target_D' : 'TX_R9MX_868_L433CB',
         'extra_D_list' : [], 'appendix' : '' 
+    },{
+        'target' : 'tx-R9MX-l433cb',                    'target_D' : 'TX_R9MX_868_L433CB',
+        'extra_D_list' : ['MLRS_FEATURE_ELRS_BOOTLOADER'], 'appendix' : '-elrs-bl' 
     },{
         'target' : 'tx-Wio-E5-Mini-wle5jc',             'target_D' : 'TX_WIO_E5_MINI_WLE5JC',
         'extra_D_list' : [], 'appendix' : '' 

--- a/tools/run_make_firmwares3.py
+++ b/tools/run_make_firmwares3.py
@@ -695,7 +695,7 @@ def mlrs_build_target(target, cmdline_D_list):
         os.path.join(MLRS_BUILD_DIR,target.build_dir,target.elf_name+'.hex')
         )
 
-    if 'for-elrs-bl' in target.build_dir:
+    if 'MLRS_FEATURE_ELRS_BOOTLOADER' in target.extra_D_list:
         os.system(
             'arm-none-eabi-objcopy -O binary ' +
             os.path.join(MLRS_BUILD_DIR,target.build_dir,target.elf_name+'.elf') + ' ' +
@@ -883,8 +883,14 @@ TLIST = [
         'target' : 'rx-R9MM-f103rb',                    'target_D' : 'RX_R9MM_868_F103RB',
         'extra_D_list' : [], 'appendix' : '' 
     },{ 
+        'target' : 'rx-R9MM-f103rb',                    'target_D' : 'RX_R9MM_868_F103RB',
+        'extra_D_list' : ['MLRS_FEATURE_ELRS_BOOTLOADER'], 'appendix' : '-for-elrs-bl' 
+    },{ 
         'target' : 'rx-R9MX-l433cb',                    'target_D' : 'RX_R9MX_868_L433CB',
         'extra_D_list' : [], 'appendix' : '' 
+    },{ 
+        'target' : 'rx-R9MX-l433cb',                    'target_D' : 'RX_R9MX_868_L433CB',
+        'extra_D_list' : ['MLRS_FEATURE_ELRS_BOOTLOADER'], 'appendix' : '-for-elrs-bl' 
     },{ 
         'target' : 'rx-Wio-E5-Grove-wle5jc',            'target_D' : 'RX_WIO_E5_GROVE_WLE5JC',
         'extra_D_list' : [], 'appendix' : '' 
@@ -945,7 +951,7 @@ TLIST = [
         'extra_D_list' : [], 'appendix' : '' 
     },{ 
         'target' : 'tx-R9M-f103c8',                     'target_D' : 'TX_R9M_868_F103C8',
-        'extra_D_list' : ['MLRS_USE_BOOTLOADER'], 'appendix' : '-for-elrs-bl' 
+        'extra_D_list' : ['MLRS_FEATURE_ELRS_BOOTLOADER'], 'appendix' : '-for-elrs-bl' 
     },{ 
         'target' : 'tx-R9MX-l433cb',                    'target_D' : 'TX_R9MX_868_L433CB',
         'extra_D_list' : [], 'appendix' : '' 

--- a/tools/run_make_firmwares3.py
+++ b/tools/run_make_firmwares3.py
@@ -695,6 +695,13 @@ def mlrs_build_target(target, cmdline_D_list):
         os.path.join(MLRS_BUILD_DIR,target.build_dir,target.elf_name+'.hex')
         )
 
+    if 'for-elrs-bl' in target.build_dir:
+        os.system(
+            'arm-none-eabi-objcopy -O binary ' +
+            os.path.join(MLRS_BUILD_DIR,target.build_dir,target.elf_name+'.elf') + ' ' +
+            os.path.join(MLRS_BUILD_DIR,target.build_dir,target.elf_name+'.elrs')
+        )
+
     print('------------------------------------------------------------')
 
 
@@ -936,6 +943,9 @@ TLIST = [
     },{ 
         'target' : 'tx-R9M-f103c8',                     'target_D' : 'TX_R9M_868_F103C8',
         'extra_D_list' : [], 'appendix' : '' 
+    },{ 
+        'target' : 'tx-R9M-f103c8',                     'target_D' : 'TX_R9M_868_F103C8',
+        'extra_D_list' : ['MLRS_USE_BOOTLOADER'], 'appendix' : '-for-elrs-bl' 
     },{ 
         'target' : 'tx-R9MX-l433cb',                    'target_D' : 'TX_R9MX_868_L433CB',
         'extra_D_list' : [], 'appendix' : '' 


### PR DESCRIPTION
Olli,  Please review this and let me know what you think of the approach I have taken here to build a second version of the R9M firmware with the proper flash address and small code changes to work with the ExpressLRS bootloader.  This produces a .elrs file which can be flashed using OpenTX or ExperssTX without needing to erase the stock Frsky bootloader or solder wires for ST-Link.

I'm still working on testing this (a previous hand-built version worked well) and I haven't even started on user documentation, but I wanted to get your feedback before I continue this work.

Elsewhere you mentioned needing to move the isr table, but this is already taken care of by the ELRS bootloader since it sets the proper VTOR value to point to our isr table before jumping to our start address (which is extracted from our table as well).

Thanks!