### PR TITLE
feat: adds support for M5Stack ATOM Lite

### DIFF
--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
@@ -69,6 +69,15 @@ UARTs can be mapped to any pins, according to data sheet
 Mates cleanly with R9M inverted serial port pins
 ATTENTION: when the 5V pin is used, one MUST not also use the USB port, since they are connected internally!!
 Disconnect from application before programming via USB. Hold down central button (G9) when connecting to USB to program
+
+------------------------------
+M5Stack ATOM Lite
+------------------------------
+board: M5Stack-ATOM
+https://shop.m5stack.com/products/atom-lite-esp32-development-kit
+http://docs.m5stack.com/en/core/atom_lite
+IO32/IO26: U0RXD/U0TXD, is remapped as Serial
+
 */
 
 /*
@@ -179,6 +188,23 @@ GPIO15 = RTC_GPIO13
     #define SERIAL_TXD  0 // = TX1
     #define SERIAL_INVERT true
 
+
+//-- M5Stack ATOM Lite
+#elif defined MODULE_M5STACK_ATOM_LITE
+    #ifndef ARDUINO_M5Stack_ATOM // ARDUINO_BOARD != ARDUINO_M5Stack_ATOM
+	      #error Select board ARDUINO_M5Stack_ATOM!
+    #endif
+
+    #undef USE_SERIAL_DBG1
+    #undef USE_SERIAL1_DBG
+
+    #define SERIAL_RXD 32 // = RX1
+    #define SERIAL_TXD 26 // = TX1
+
+    #undef LED_IO
+    #define USE_LED
+    #define NUMPIXELS  1
+    #define PIN_NEOPIXEL  27
 
 //-- Generic
 #else

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -28,6 +28,8 @@ for more details on the boards see mlrs-wifi-bridge-boards.h
 - M5Stack M5Stamp C3U Mate
   board: ESP32C3 Dev Module
   ATTENTION: when the 5V pin is used, one MUST not also use the USB port, since they are connected internally!!
+- M5Stack ATOM Lite
+  board: M5Stack-ATOM
 */
 
 #include <WiFi.h>
@@ -46,6 +48,7 @@ for more details on the boards see mlrs-wifi-bridge-boards.h
 //#define MODULE_ESP32_PICO_KIT
 //#define MODULE_M5STAMP_C3U_MATE_FOR_FRSKY_R9M
 //#define MODULE_M5STAMP_PICO_FOR_FRSKY_R9M
+//#define MODULE_M5STACK_ATOM_LITE
 
 
 // Wifi Protocol 0 = TCP, 1 = UDP


### PR DESCRIPTION
Usage: connect M5Stack ATOM Lite to mLRS via HY2.0-4P connectors G32 (RX of mlrs-wifi-bridge) and G26 (TX of mlrs-wifi-bridge).

![grafik](https://github.com/olliw42/mLRS/assets/21011587/e49fe32d-356c-4784-9f5f-f325f1482b07)

The RGB LED of ATOM Lite will be used for signalling - blinking red while waiting for connection and blinking green for connected state.