### PR TITLE
Added std. "ESP32 Dev Module"

### DIFF
--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
@@ -120,9 +120,6 @@ GPIO15 = RTC_GPIO13
 
     #define SERIAL_RXD 16 // = RX2
     #define SERIAL_TXD 17 // = TX2
-  #if defined USE_SERIAL_INVERTED
-    #define SERIAL_INVERT true
-  #endif
 
     #undef USE_LED
 
@@ -139,9 +136,6 @@ GPIO15 = RTC_GPIO13
 
     #define SERIAL_RXD 16 // = RX2
     #define SERIAL_TXD 17 // = TX2
-  #if defined USE_SERIAL_INVERTED
-    #define SERIAL_INVERT true
-  #endif
 
     #ifndef LED_IO
         #define LED_IO  2
@@ -177,9 +171,6 @@ GPIO15 = RTC_GPIO13
 
     #define SERIAL_RXD 3 // = RX
     #define SERIAL_TXD 1 // = TX
-  #if defined USE_SERIAL_INVERTED
-    #define SERIAL_INVERT true
-  #endif
 
     #ifndef LED_IO
         #define LED_IO  13
@@ -199,9 +190,6 @@ GPIO15 = RTC_GPIO13
     
     #define SERIAL_RXD 18 // = RX1
     #define SERIAL_TXD 17 // = TX1
-  #if defined USE_SERIAL_INVERTED
-    #define SERIAL_INVERT true
-  #endif
 
     #undef LED_IO
     #define USE_LED
@@ -221,9 +209,6 @@ GPIO15 = RTC_GPIO13
 
     #define SERIAL_RXD 18 // = RX1
     #define SERIAL_TXD 19 // = TX1
-  #if defined USE_SERIAL_INVERTED
-    #define SERIAL_INVERT true
-  #endif
 
     #undef LED_IO
     #define USE_LED
@@ -243,9 +228,6 @@ GPIO15 = RTC_GPIO13
 
     #define SERIAL_RXD  32 // = RX1
     #define SERIAL_TXD  33 // = TX1
-  #if defined USE_SERIAL_INVERTED
-    #define SERIAL_INVERT true
-  #endif
 
     #undef LED_IO
     #define USE_LED
@@ -265,9 +247,6 @@ GPIO15 = RTC_GPIO13
 
     #define SERIAL_RXD  1 // = RX1
     #define SERIAL_TXD  0 // = TX1
-  #if defined USE_SERIAL_INVERTED
-    #define SERIAL_INVERT true
-  #endif
 
     #undef LED_IO
     #define USE_LED
@@ -287,9 +266,6 @@ GPIO15 = RTC_GPIO13
 
     #define SERIAL_RXD 32 // = RX1
     #define SERIAL_TXD 26 // = TX1
-  #if defined USE_SERIAL_INVERTED
-    #define SERIAL_INVERT true
-  #endif
 
     #undef LED_IO
     #define USE_LED

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
@@ -18,11 +18,19 @@ IO9/IO10: U1RXD/U1TXD, is Serial1
 IO16/IO17: U2RXD/U2TXD, uses IO16/IO17 for internal flash, hence not available as serial
 
 ------------------------------
-NodeMCU ESP32-Wroom-32 or ESP32-DevKitC V4
+Espressif ESP32-DevKitC V4
+------------------------------
+board: ESP32 Dev Module
+https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-devkitc.html
+IO3/IO1: U0RXD/U0TXD, connected via usb-ttl adapter to USB port, is Serial, spits out lots of preamble at power up
+IO16/IO17: U2RXD/U2TXD, is Serial2
+
+
+------------------------------
+NodeMCU ESP32-Wroom-32
 ------------------------------
 board: ESP32 Dev Module
 https://esphome.io/devices/nodemcu_esp32.html
-https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-devkitc.html
 IO3/IO1: U0RXD/U0TXD, connected via usb-ttl adapter to USB port, is Serial, spits out lots of preamble at power up
 IO16/IO17: U2RXD/U2TXD, is Serial2
 
@@ -100,25 +108,8 @@ GPIO15 = RTC_GPIO13
 //-------------------------------------------------------
 // board details
 //-------------------------------------------------------
-//-- NodeMCU ESP32-Wroom-32 or ESP32-DevKitC V4
-#if defined MODULE_NODEMCU_ESP32_WROOM32
-    #ifndef ARDUINO_ESP32_DEV // ARDUINO_BOARD != ARDUINO_ESP32_DEV
-	      #error Select board ESP32 Dev Module!
-    #endif
-
-    #undef USE_SERIAL_DBG1
-    #undef USE_SERIAL1_DBG
-    #define USE_SERIAL2_DBG
-
-    // ESP32-DevKitC V4 does not have embedded LED
-    #ifndef LED_IO
-        #define LED_IO  2
-    #endif    
-    #define USE_LED
-
-
-//-- NodeMCU ESP32-Wroom-32 or ESP32-DevKitC V4 (inverted serial)
-#elif defined MODULE_NODEMCU_ESP32_WROOM32_SERIAL_INVERTED
+//-- Espressif ESP32-DevKitC V4
+#if defined MODULE_ESP32_WROOM32
     #ifndef ARDUINO_ESP32_DEV // ARDUINO_BOARD != ARDUINO_ESP32_DEV
 	      #error Select board ESP32 Dev Module!
     #endif
@@ -129,9 +120,29 @@ GPIO15 = RTC_GPIO13
 
     #define SERIAL_RXD 16 // = RX2
     #define SERIAL_TXD 17 // = TX2
+  #if defined USE_SERIAL_INVERTED
     #define SERIAL_INVERT true
+  #endif
 
-    // ESP32-DevKitC V4 does not have embedded LED
+    #undef USE_LED
+
+
+//-- NodeMCU ESP32-Wroom-32
+#elif defined MODULE_NODEMCU_ESP32_WROOM32
+    #ifndef ARDUINO_ESP32_DEV // ARDUINO_BOARD != ARDUINO_ESP32_DEV
+	      #error Select board ESP32 Dev Module!
+    #endif
+
+    #undef USE_SERIAL_DBG1
+    #undef USE_SERIAL1_DBG
+    #define USE_SERIAL2_DBG
+
+    #define SERIAL_RXD 16 // = RX2
+    #define SERIAL_TXD 17 // = TX2
+  #if defined USE_SERIAL_INVERTED
+    #define SERIAL_INVERT true
+  #endif
+
     #ifndef LED_IO
         #define LED_IO  2
     #endif    
@@ -164,6 +175,12 @@ GPIO15 = RTC_GPIO13
     #undef USE_SERIAL1_DBG
     #undef USE_SERIAL2_DBG
 
+    #define SERIAL_RXD 3 // = RX
+    #define SERIAL_TXD 1 // = TX
+  #if defined USE_SERIAL_INVERTED
+    #define SERIAL_INVERT true
+  #endif
+
     #ifndef LED_IO
         #define LED_IO  13
     #endif    
@@ -180,6 +197,12 @@ GPIO15 = RTC_GPIO13
     #define USE_SERIAL1_DBG
     #undef USE_SERIAL2_DBG
     
+    #define SERIAL_RXD 18 // = RX1
+    #define SERIAL_TXD 17 // = TX1
+  #if defined USE_SERIAL_INVERTED
+    #define SERIAL_INVERT true
+  #endif
+
     #undef LED_IO
     #define USE_LED
     #define NUMPIXELS  1
@@ -195,6 +218,12 @@ GPIO15 = RTC_GPIO13
     #undef USE_SERIAL_DBG1
     #define USE_SERIAL1_DBG
     #undef USE_SERIAL2_DBG
+
+    #define SERIAL_RXD 18 // = RX1
+    #define SERIAL_TXD 19 // = TX1
+  #if defined USE_SERIAL_INVERTED
+    #define SERIAL_INVERT true
+  #endif
 
     #undef LED_IO
     #define USE_LED
@@ -212,14 +241,16 @@ GPIO15 = RTC_GPIO13
     #define USE_SERIAL1_DBG
     #undef USE_SERIAL2_DBG
 
+    #define SERIAL_RXD  32 // = RX1
+    #define SERIAL_TXD  33 // = TX1
+  #if defined USE_SERIAL_INVERTED
+    #define SERIAL_INVERT true
+  #endif
+
     #undef LED_IO
     #define USE_LED
     #define NUMPIXELS  1
     #define PIN_NEOPIXEL  27
-
-    #define SERIAL_RXD  32 // = RX1
-    #define SERIAL_TXD  33 // = TX1
-    #define SERIAL_INVERT true
 
 
 //-- M5Stack M5Stamp C3U Mate
@@ -232,14 +263,16 @@ GPIO15 = RTC_GPIO13
     #define USE_SERIAL1_DBG
     #undef USE_SERIAL2_DBG
 
+    #define SERIAL_RXD  1 // = RX1
+    #define SERIAL_TXD  0 // = TX1
+  #if defined USE_SERIAL_INVERTED
+    #define SERIAL_INVERT true
+  #endif
+
     #undef LED_IO
     #define USE_LED
     #define NUMPIXELS  1
     #define PIN_NEOPIXEL  2
-
-    #define SERIAL_RXD  1 // = RX1
-    #define SERIAL_TXD  0 // = TX1
-    #define SERIAL_INVERT true
 
 
 //-- M5Stack ATOM Lite
@@ -254,6 +287,9 @@ GPIO15 = RTC_GPIO13
 
     #define SERIAL_RXD 32 // = RX1
     #define SERIAL_TXD 26 // = TX1
+  #if defined USE_SERIAL_INVERTED
+    #define SERIAL_INVERT true
+  #endif
 
     #undef LED_IO
     #define USE_LED

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
@@ -18,6 +18,14 @@ IO9/IO10: U1RXD/U1TXD, is Serial1
 IO16/IO17: U2RXD/U2TXD, uses IO16/IO17 for internal flash, hence not available as serial
 
 ------------------------------
+NodeMCU ESP32-Wroom-32
+------------------------------
+board: ESP32 Dev Module
+https://esphome.io/devices/nodemcu_esp32.html
+IO3/IO1: U0RXD/U0TXD, connected via usb-ttl adapter to USB port, is Serial, spits out lots of preamble at power up
+IO16/IO17: U2RXD/U2TXD, is Serial2
+
+------------------------------
 Lilygo TTGO-MICRO32
 ------------------------------
 board: ESP32-PICO-D4
@@ -91,8 +99,44 @@ GPIO15 = RTC_GPIO13
 //-------------------------------------------------------
 // board details
 //-------------------------------------------------------
+//-- ESP32 Dev Module
+#if defined MODULE_ESP32_DEV
+    #ifndef ARDUINO_ESP32_DEV // ARDUINO_BOARD != ARDUINO_ESP32_DEV
+	      #error Select board ESP32 Dev Module!
+    #endif
+
+    #undef USE_SERIAL_DBG1
+    #undef USE_SERIAL1_DBG
+    #define USE_SERIAL2_DBG
+
+    #ifndef LED_IO
+        #define LED_IO  2
+    #endif    
+    #define USE_LED
+
+
+//-- ESP32 Dev Module (inverted serial)
+#elif defined MODULE_ESP32_DEV_INV
+    #ifndef ARDUINO_ESP32_DEV // ARDUINO_BOARD != ARDUINO_ESP32_DEV
+	      #error Select board ESP32 Dev Module!
+    #endif
+
+    #undef USE_SERIAL_DBG1
+    #undef USE_SERIAL1_DBG
+    #define USE_SERIAL2_DBG
+
+    #define SERIAL_RXD 16 // = RX2
+    #define SERIAL_TXD 17 // = TX2
+    #define SERIAL_INVERT true
+
+    #ifndef LED_IO
+        #define LED_IO  2
+    #endif    
+    #define USE_LED
+
+
 //-- ESP32-PICO-KIT
-#if defined MODULE_ESP32_PICO_KIT // ARDUINO_ESP32_PICO, ARDUINO_BOARD = ESP32_PICO
+#elif defined MODULE_ESP32_PICO_KIT // ARDUINO_ESP32_PICO, ARDUINO_BOARD = ESP32_PICO
     #ifndef ARDUINO_ESP32_PICO // ARDUINO_BOARD != ESP32_PICO
 	      #error Select board ARDUINO_ESP32_PICO!
     #endif
@@ -192,7 +236,7 @@ GPIO15 = RTC_GPIO13
 //-- M5Stack ATOM Lite
 #elif defined MODULE_M5STACK_ATOM_LITE
     #ifndef ARDUINO_M5Stack_ATOM // ARDUINO_BOARD != ARDUINO_M5Stack_ATOM
-	      #error Select board ARDUINO_M5Stack_ATOM!
+	      #error Select board M5Stack-ATOM!
     #endif
 
     #undef USE_SERIAL_DBG1
@@ -205,6 +249,7 @@ GPIO15 = RTC_GPIO13
     #define USE_LED
     #define NUMPIXELS  1
     #define PIN_NEOPIXEL  27
+
 
 //-- Generic
 #else
@@ -261,7 +306,13 @@ GPIO15 = RTC_GPIO13
     #define DBG Serial
     #define DBG_PRINT(x) Serial.print(x)
     #define DBG_PRINTLN(x) Serial.println(x)
-    
+
+#elif defined USE_SERIAL2_DBG
+    #define SERIAL Serial2
+    #define DBG Serial
+    #define DBG_PRINT(x) Serial.print(x)
+    #define DBG_PRINTLN(x) Serial.println(x)
+
 #else    
     #define SERIAL Serial
     #define DBG_PRINT(x)

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
@@ -100,7 +100,7 @@ GPIO15 = RTC_GPIO13
 // board details
 //-------------------------------------------------------
 //-- ESP32 Dev Module
-#if defined MODULE_ESP32_DEV
+#if defined MODULE_NODEMCU_ESP32_WROOM32
     #ifndef ARDUINO_ESP32_DEV // ARDUINO_BOARD != ARDUINO_ESP32_DEV
 	      #error Select board ESP32 Dev Module!
     #endif
@@ -116,7 +116,7 @@ GPIO15 = RTC_GPIO13
 
 
 //-- ESP32 Dev Module (inverted serial)
-#elif defined MODULE_ESP32_DEV_INV
+#elif defined MODULE_NODEMCU_ESP32_WROOM32_SERIAL_INVERTED
     #ifndef ARDUINO_ESP32_DEV // ARDUINO_BOARD != ARDUINO_ESP32_DEV
 	      #error Select board ESP32 Dev Module!
     #endif
@@ -143,6 +143,7 @@ GPIO15 = RTC_GPIO13
 
     #undef USE_SERIAL_DBG1
     #define USE_SERIAL1_DBG
+    #undef USE_SERIAL2_DBG
 
     #ifndef LED_IO
         #define LED_IO  13
@@ -158,6 +159,7 @@ GPIO15 = RTC_GPIO13
 
     #undef USE_SERIAL_DBG1
     #undef USE_SERIAL1_DBG
+    #undef USE_SERIAL2_DBG
 
     #ifndef LED_IO
         #define LED_IO  13
@@ -173,6 +175,7 @@ GPIO15 = RTC_GPIO13
 
     #undef USE_SERIAL_DBG1
     #define USE_SERIAL1_DBG
+    #undef USE_SERIAL2_DBG
     
     #undef LED_IO
     #define USE_LED
@@ -188,6 +191,7 @@ GPIO15 = RTC_GPIO13
 
     #undef USE_SERIAL_DBG1
     #define USE_SERIAL1_DBG
+    #undef USE_SERIAL2_DBG
 
     #undef LED_IO
     #define USE_LED
@@ -203,6 +207,7 @@ GPIO15 = RTC_GPIO13
 
     #undef USE_SERIAL_DBG1
     #define USE_SERIAL1_DBG
+    #undef USE_SERIAL2_DBG
 
     #undef LED_IO
     #define USE_LED
@@ -222,6 +227,7 @@ GPIO15 = RTC_GPIO13
 
     #undef USE_SERIAL_DBG1
     #define USE_SERIAL1_DBG
+    #undef USE_SERIAL2_DBG
 
     #undef LED_IO
     #define USE_LED
@@ -236,11 +242,12 @@ GPIO15 = RTC_GPIO13
 //-- M5Stack ATOM Lite
 #elif defined MODULE_M5STACK_ATOM_LITE
     #ifndef ARDUINO_M5Stack_ATOM // ARDUINO_BOARD != ARDUINO_M5Stack_ATOM
-	      #error Select board M5Stack-ATOM!
+	      #error Select board ARDUINO_M5Stack_ATOM!
     #endif
 
     #undef USE_SERIAL_DBG1
     #undef USE_SERIAL1_DBG
+    #undef USE_SERIAL2_DBG
 
     #define SERIAL_RXD 32 // = RX1
     #define SERIAL_TXD 26 // = TX1

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
@@ -227,6 +227,7 @@ GPIO15 = RTC_GPIO13
 
     #define SERIAL_RXD  32 // = RX1
     #define SERIAL_TXD  33 // = TX1
+    #define USE_SERIAL_INVERTED
 
     #undef LED_IO
     #define USE_LED
@@ -246,6 +247,7 @@ GPIO15 = RTC_GPIO13
 
     #define SERIAL_RXD  1 // = RX1
     #define SERIAL_TXD  0 // = TX1
+    #define USE_SERIAL_INVERTED
 
     #undef LED_IO
     #define USE_LED
@@ -323,7 +325,6 @@ GPIO15 = RTC_GPIO13
     #define SERIAL Serial1
 //    #define SERIAL_RXD  9 // = RX1
 //    #define SERIAL_TXD  10 // = TX1
-//    #define SERIAL_INVERT false
     #define DBG Serial
     #define DBG_PRINT(x) Serial.print(x)
     #define DBG_PRINTLN(x) Serial.println(x)

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
@@ -25,7 +25,6 @@ https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/g
 IO3/IO1: U0RXD/U0TXD, connected via usb-ttl adapter to USB port, is Serial, spits out lots of preamble at power up
 IO16/IO17: U2RXD/U2TXD, is Serial2
 
-
 ------------------------------
 NodeMCU ESP32-Wroom-32
 ------------------------------
@@ -109,7 +108,7 @@ GPIO15 = RTC_GPIO13
 // board details
 //-------------------------------------------------------
 //-- Espressif ESP32-DevKitC V4
-#if defined MODULE_ESP32_WROOM32
+#if defined MODULE_ESP32_DEVKITC_V4
     #ifndef ARDUINO_ESP32_DEV // ARDUINO_BOARD != ARDUINO_ESP32_DEV
 	      #error Select board ESP32 Dev Module!
     #endif

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
@@ -18,10 +18,11 @@ IO9/IO10: U1RXD/U1TXD, is Serial1
 IO16/IO17: U2RXD/U2TXD, uses IO16/IO17 for internal flash, hence not available as serial
 
 ------------------------------
-NodeMCU ESP32-Wroom-32
+NodeMCU ESP32-Wroom-32 or ESP32-DevKitC V4
 ------------------------------
 board: ESP32 Dev Module
 https://esphome.io/devices/nodemcu_esp32.html
+https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-devkitc.html
 IO3/IO1: U0RXD/U0TXD, connected via usb-ttl adapter to USB port, is Serial, spits out lots of preamble at power up
 IO16/IO17: U2RXD/U2TXD, is Serial2
 
@@ -99,7 +100,7 @@ GPIO15 = RTC_GPIO13
 //-------------------------------------------------------
 // board details
 //-------------------------------------------------------
-//-- ESP32 Dev Module
+//-- NodeMCU ESP32-Wroom-32 or ESP32-DevKitC V4
 #if defined MODULE_NODEMCU_ESP32_WROOM32
     #ifndef ARDUINO_ESP32_DEV // ARDUINO_BOARD != ARDUINO_ESP32_DEV
 	      #error Select board ESP32 Dev Module!
@@ -115,7 +116,7 @@ GPIO15 = RTC_GPIO13
     #define USE_LED
 
 
-//-- ESP32 Dev Module (inverted serial)
+//-- NodeMCU ESP32-Wroom-32 or ESP32-DevKitC V4 (inverted serial)
 #elif defined MODULE_NODEMCU_ESP32_WROOM32_SERIAL_INVERTED
     #ifndef ARDUINO_ESP32_DEV // ARDUINO_BOARD != ARDUINO_ESP32_DEV
 	      #error Select board ESP32 Dev Module!

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge-boards.h
@@ -110,6 +110,7 @@ GPIO15 = RTC_GPIO13
     #undef USE_SERIAL1_DBG
     #define USE_SERIAL2_DBG
 
+    // ESP32-DevKitC V4 does not have embedded LED
     #ifndef LED_IO
         #define LED_IO  2
     #endif    
@@ -130,6 +131,7 @@ GPIO15 = RTC_GPIO13
     #define SERIAL_TXD 17 // = TX2
     #define SERIAL_INVERT true
 
+    // ESP32-DevKitC V4 does not have embedded LED
     #ifndef LED_IO
         #define LED_IO  2
     #endif    

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -143,7 +143,7 @@ void setup()
     size_t txbufsize = SERIAL.setTxBufferSize(512); // must come before uart started, retuns 0 if it fails
 #ifdef SERIAL_RXD // if SERIAL_TXD is not defined the compiler will complain, so all good
   #ifdef USE_SERIAL_INVERTED
-    SERIAL.begin(baudrate, SERIAL_8N1, SERIAL_RXD, SERIAL_TXD, SERIAL_INVERT);
+    SERIAL.begin(baudrate, SERIAL_8N1, SERIAL_RXD, SERIAL_TXD, true);
   #else
     SERIAL.begin(baudrate, SERIAL_8N1, SERIAL_RXD, SERIAL_TXD);
   #endif

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -44,8 +44,8 @@ for more details on the boards see mlrs-wifi-bridge-boards.h
 // Board
 // un-comment what you want
 //#define MODULE_GENERIC
-//#define MODULE_ESP32_DEV
-//#define MODULE_ESP32_DEV_INV
+//#define MODULE_NODEMCU_ESP32_WROOM32
+//#define MODULE_NODEMCU_ESP32_WROOM32_SERIAL_INVERTED
 #define MODULE_ADAFRUIT_QT_PY_ESP32_S2
 //#define MODULE_M5STAMP_C3_MATE
 //#define MODULE_TTGO_MICRO32

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -14,6 +14,8 @@
 /*
 for more details on the boards see mlrs-wifi-bridge-boards.h
 
+- Espressif ESP32-DevKitC V4
+  board: ESP32 Dev Module
 - NodeMCU ESP32-Wroom-32
   board: ESP32 Dev Module
 - Adafruit QT Py S2
@@ -44,7 +46,7 @@ for more details on the boards see mlrs-wifi-bridge-boards.h
 // Board
 // un-comment what you want
 //#define MODULE_GENERIC
-//#define MODULE_ESP32_WROOM32
+//#define MODULE_ESP32_DEVKITC_V4
 //#define MODULE_NODEMCU_ESP32_WROOM32
 #define MODULE_ADAFRUIT_QT_PY_ESP32_S2
 //#define MODULE_M5STAMP_C3_MATE

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -140,7 +140,7 @@ void setup()
     size_t rxbufsize = SERIAL.setRxBufferSize(2*1024); // must come before uart started, retuns 0 if it fails
     size_t txbufsize = SERIAL.setTxBufferSize(512); // must come before uart started, retuns 0 if it fails
 #ifdef SERIAL_RXD // if SERIAL_TXD is not defined the compiler will complain, so all good
-  #ifdef SERIAL_INVERT
+  #ifdef USE_SERIAL_INVERTED
     SERIAL.begin(baudrate, SERIAL_8N1, SERIAL_RXD, SERIAL_TXD, SERIAL_INVERT);
   #else
     SERIAL.begin(baudrate, SERIAL_8N1, SERIAL_RXD, SERIAL_TXD);

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -57,7 +57,7 @@ for more details on the boards see mlrs-wifi-bridge-boards.h
 //#define MODULE_M5STACK_ATOM_LITE
 
 // Uncomment, if you need inverted serial
-#define USE_SERIAL_INVERTED
+//#define USE_SERIAL_INVERTED
 
 // Wifi Protocol 0 = TCP, 1 = UDP
 #define WIFI_PROTOCOL  1

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -44,8 +44,8 @@ for more details on the boards see mlrs-wifi-bridge-boards.h
 // Board
 // un-comment what you want
 //#define MODULE_GENERIC
+//#define MODULE_ESP32_WROOM32
 //#define MODULE_NODEMCU_ESP32_WROOM32
-//#define MODULE_NODEMCU_ESP32_WROOM32_SERIAL_INVERTED
 #define MODULE_ADAFRUIT_QT_PY_ESP32_S2
 //#define MODULE_M5STAMP_C3_MATE
 //#define MODULE_TTGO_MICRO32
@@ -54,6 +54,8 @@ for more details on the boards see mlrs-wifi-bridge-boards.h
 //#define MODULE_M5STAMP_PICO_FOR_FRSKY_R9M
 //#define MODULE_M5STACK_ATOM_LITE
 
+// Uncomment, if you need inverted serial
+#define USE_SERIAL_INVERTED
 
 // Wifi Protocol 0 = TCP, 1 = UDP
 #define WIFI_PROTOCOL  1

--- a/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
+++ b/esp/mlrs-wifi-bridge/mlrs-wifi-bridge.ino
@@ -14,6 +14,8 @@
 /*
 for more details on the boards see mlrs-wifi-bridge-boards.h
 
+- NodeMCU ESP32-Wroom-32
+  board: ESP32 Dev Module
 - Adafruit QT Py S2
   board: Adafruit QT Py ESP32-S2
 - M5Stack M5Stamp C3 Mate
@@ -42,6 +44,8 @@ for more details on the boards see mlrs-wifi-bridge-boards.h
 // Board
 // un-comment what you want
 //#define MODULE_GENERIC
+//#define MODULE_ESP32_DEV
+//#define MODULE_ESP32_DEV_INV
 #define MODULE_ADAFRUIT_QT_PY_ESP32_S2
 //#define MODULE_M5STAMP_C3_MATE
 //#define MODULE_TTGO_MICRO32
@@ -80,6 +84,7 @@ int wifi_channel = 13;
 // comment all for default behavior, which is using only Serial port
 //#define USE_SERIAL_DBG1 // use Serial for communication and flashing, and Serial1 for debug output
 //#define USE_SERIAL1_DBG // use Serial1 for communication, and Serial for debug output and flashing
+//#define USE_SERIAL2_DBG // use Serial2 for communication, and Serial for debug output and flashing
 
 // LED pin (only effective for a generic board)
 // un-comment if you want a LED


### PR DESCRIPTION
Added std. "ESP32 Dev Module" (e.g. NodeMCU ESP32-WROOM-32) as a new option. Including also an inverted serial version for usage e.g. with FrSky R9M.

According to Discord user hooman, this code works with his R9M and NodeMCU ESP32-WROOM-32.

Update: tested myself with ESP32-DevKitC V4 with ESP32-WROOM-32D as well.