### PR TITLE
Provide an option to lower CPU frequency for M5Stack ATOM Lite.

### DIFF
--- a/esp/mlrs-wireless-bridge/mlrs-wireless-bridge-boards.h
+++ b/esp/mlrs-wireless-bridge/mlrs-wireless-bridge-boards.h
@@ -277,6 +277,8 @@ GPIO15 = RTC_GPIO13
     #define NUMPIXELS  1
     #define PIN_NEOPIXEL  27
 
+    #define CPUFREQMHZ 160 // Options 80, 160, 240 MHz
+
 
 //-- Generic
 #else

--- a/esp/mlrs-wireless-bridge/mlrs-wireless-bridge.ino
+++ b/esp/mlrs-wireless-bridge/mlrs-wireless-bridge.ino
@@ -187,6 +187,9 @@ void serialFlushRx(void)
 
 void setup()
 {
+#ifdef CPUFREQMHZ
+    setCpuFrequencyMhz(CPUFREQMHZ);
+#endif
     led_init();
     dbg_init();
     delay(500);


### PR DESCRIPTION
Keeps ESP32 CPU running cooler and taking less energy. Experimentally found out that 160 MHz is still enough at least for UDP connectivity. Lowering further down to 80 MHz, did not get nice results anymore.