### PR TITLE
feat: added support for VCP on G4

### DIFF
--- a/mLRS/modules/stm32-usb-device/usbd_conf.c
+++ b/mLRS/modules/stm32-usb-device/usbd_conf.c
@@ -23,6 +23,11 @@
 #include "usbd_cdc.h"
 #include "usbd_conf.h"
 
+#ifndef USB_IRQn
+  #ifdef USB_LP_IRQn
+    #define USB_IRQn USB_LP_IRQn
+  #endif
+#endif
 
 PCD_HandleTypeDef hpcd_USB_FS;
 void Error_Handler(void);

--- a/mLRS/modules/stm32-usb-device/usbd_conf.h
+++ b/mLRS/modules/stm32-usb-device/usbd_conf.h
@@ -30,9 +30,7 @@ extern "C" {
 #ifdef STM32F072xB
 #include "stm32f0xx.h"
 #include "stm32f0xx_hal.h"
-#endif
- 
-#ifdef STM32G431xx
+#elif defined STM32G431xx
 #include "stm32g4xx.h"
 #include "stm32g4xx_hal.h"
 #endif

--- a/mLRS/modules/stm32-usb-device/usbd_conf.h
+++ b/mLRS/modules/stm32-usb-device/usbd_conf.h
@@ -26,8 +26,16 @@ extern "C" {
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef STM32F072xB
 #include "stm32f0xx.h"
 #include "stm32f0xx_hal.h"
+#endif
+ 
+#ifdef STM32G431xx
+#include "stm32g4xx.h"
+#include "stm32g4xx_hal.h"
+#endif
 
 
 #define USBD_MAX_NUM_INTERFACES                     1U

--- a/tools/run_copy_st_drivers.py
+++ b/tools/run_copy_st_drivers.py
@@ -112,6 +112,8 @@ g4xx_hal_files_to_include = [
   'stm32g4xx_hal_dma.c',
   'stm32g4xx_hal_i2c.c',
   'stm32g4xx_hal_i2c_ex.c',
+  'stm32g4xx_hal_pcd.c',
+  'stm32g4xx_hal_pcd_ex.c',
 ]
 
 wlxx_hal_files_to_include = [

--- a/tools/run_make_firmwares3.py
+++ b/tools/run_make_firmwares3.py
@@ -215,6 +215,8 @@ MLRS_SOURCES_HAL_STM32G4 = [
     os.path.join('Drivers','STM32G4xx_HAL_Driver','Src','stm32g4xx_hal.c'),
     os.path.join('Drivers','STM32G4xx_HAL_Driver','Src','stm32g4xx_hal_cortex.c'),
     os.path.join('Drivers','STM32G4xx_HAL_Driver','Src','stm32g4xx_hal_dma.c'),
+    os.path.join('Drivers','STM32G4xx_HAL_Driver','Src','stm32g4xx_hal_pcd.c'),
+    os.path.join('Drivers','STM32G4xx_HAL_Driver','Src','stm32g4xx_hal_pcd_ex.c'),
     os.path.join('Drivers','STM32G4xx_HAL_Driver','Src','stm32g4xx_hal_flash.c'),
     os.path.join('Drivers','STM32G4xx_HAL_Driver','Src','stm32g4xx_hal_flash_ex.c'),
     os.path.join('Drivers','STM32G4xx_HAL_Driver','Src','stm32g4xx_hal_i2c.c'),


### PR DESCRIPTION
as discussed on the dirscord the first PR for supporting VCP on G4 MCUs. you @olliw42 already mentioned there isn't (a currently known) better way to define the includes for the G4 series in `mLRS/modules/stm32-usb-device/usbd_conf.h`.

Edits/Reviews/Suggestions to this PRs are as always welcome.