### PR TITLE
feat: added UsbClockSelection for STM32G431xx

### DIFF
--- a/mLRS/modules/stm32-usb-device/usbd_cdc_if.c
+++ b/mLRS/modules/stm32-usb-device/usbd_cdc_if.c
@@ -59,6 +59,18 @@ static uint8_t usbd_initialized = 0; // to track if we use usb
 
 void usb_init(void)
 {
+#if defined STM32G431xx
+    // initialize HSI48, copied with adaption from SystemClock_Config()
+    RCC_OscInitTypeDef RCC_OscInitStruct = {};
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI48;
+    RCC_OscInitStruct.HSI48State = RCC_HSI48_ON;
+    // important, since otherwise HAL_RCC_OscConfig() wouldn't set it
+    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        //Error_Handler();
+    }
+#endif
+
     // copied from SystemClock_Config()
     RCC_PeriphCLKInitTypeDef PeriphClkInit = {};
     PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USB;

--- a/mLRS/modules/stm32-usb-device/usbd_cdc_if.c
+++ b/mLRS/modules/stm32-usb-device/usbd_cdc_if.c
@@ -117,6 +117,14 @@ void usb_deinit(void)
     if (!usbd_initialized) return;
 
     USBD_DeInit(&husbd_CDC);
+
+#if defined STM32G431xx
+    RCC_OscInitTypeDef RCC_OscInitStruct = {};
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI48;
+    RCC_OscInitStruct.HSI48State = RCC_HSI48_OFF;
+    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE; // important, otherwise HAL_RCC_OscConfig() would set PLL
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {}
+#endif
 }
 
 

--- a/mLRS/modules/stm32-usb-device/usbd_cdc_if.c
+++ b/mLRS/modules/stm32-usb-device/usbd_cdc_if.c
@@ -64,8 +64,7 @@ void usb_init(void)
     RCC_OscInitTypeDef RCC_OscInitStruct = {};
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI48;
     RCC_OscInitStruct.HSI48State = RCC_HSI48_ON;
-    // important, since otherwise HAL_RCC_OscConfig() wouldn't set it
-    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE; // important, otherwise HAL_RCC_OscConfig() would set PLL
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         //Error_Handler();
     }
@@ -77,6 +76,7 @@ void usb_init(void)
 #if defined STM32F103xE
     PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_PLL_DIV1_5;
 #elif defined STM32G431xx
+    // CubeMX is not adding this to SystemClock_Config(), but it is needed
     PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
 #elif defined STM32F072xB
     PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_PLL;

--- a/mLRS/modules/stm32-usb-device/usbd_cdc_if.c
+++ b/mLRS/modules/stm32-usb-device/usbd_cdc_if.c
@@ -65,7 +65,7 @@ void usb_init(void)
 #if defined STM32F103xE
     PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_PLL_DIV1_5;
 #elif defined STM32G431xx
-    // TODO
+    PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
 #elif defined STM32F072xB
     PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_PLL;
 #endif


### PR DESCRIPTION
implemented UsbClockSelection for the STM32G431xx. My hardware is running in this configuration since last week.
https://github.com/Gurkengewuerz/mLRS-custom-builds/blob/main/customTargets/mc8051-diy-g431cb/Core/Src/main.cpp#L170-L176

Tested on STM32G431CB