### PR TITLE
SX127x_power_fix

### DIFF
--- a/mLRS/Common/sx-drivers/sx127x_driver.h
+++ b/mLRS/Common/sx-drivers/sx127x_driver.h
@@ -43,14 +43,14 @@ const tSxLoraConfiguration Sx127xLoraConfiguration[] = {
 void sx1276_rfpower_calc(const int8_t power_dbm, uint8_t* sx_power, int8_t* actual_power_dbm, const uint8_t GAIN_DBM, const uint8_t SX1276_MAX_DBM)
 {
     // Pout = 17 - (15 - OutputPower) if PaSelect = 1 (PA_BOOST pin)
-    int16_t power_sx = (int16_t)power_dbm - GAIN_DBM + 2;
+    int16_t power_sx = (int16_t)power_dbm - GAIN_DBM - 2;
 
     if (power_sx < SX1276_OUTPUT_POWER_MIN) power_sx = SX1276_OUTPUT_POWER_MIN;
     if (power_sx > SX1276_OUTPUT_POWER_MAX) power_sx = SX1276_OUTPUT_POWER_MAX;
     if (power_sx > SX1276_MAX_DBM) power_sx = SX1276_MAX_DBM;
 
     *sx_power = power_sx;
-    *actual_power_dbm = power_sx + GAIN_DBM - 2;
+    *actual_power_dbm = power_sx + GAIN_DBM + 2;
 }
 #endif
 


### PR DESCRIPTION
Related to: https://github.com/olliw42/mLRS/issues/139 Tested on R9 MX, Lua now reports expected value.

Previously, one would get a 'free' 4 dBm on power levels < 15 dBm.