### PR TITLE
esp, platformio.ini prepare for tx

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,14 @@ monitor_speed = 115200
 ; common environments
 ;--------------------
 
-[env_common]
+[env_common_esp82xx]
+platform = espressif8266@4.2.1
+board_build.f_cpu = 160000000L
+build_type = release
+
+; RX
+
+[env_common_rx]
 build_src_filter =
   -<*>
   +<CommonRx/mlrs-rx.cpp>
@@ -33,11 +40,10 @@ build_src_filter =
   +<modules/stm32ll-lib/src/stdstm32.c>
 
 
-[env_common_esp82xx]
-platform = espressif8266@4.2.1
-board_build.f_cpu = 160000000L
-build_type = release
-build_src_filter = ${env_common.build_src_filter}
+[env_common_rx_esp82xx]
+extends = env_common_esp82xx
+build_src_filter = ${env_common_rx.build_src_filter}
+
 
 ;--------------------
 ; target boards
@@ -46,40 +52,40 @@ build_src_filter = ${env_common.build_src_filter}
 ; ELRS generic layouts
 
 [env:rx-generic-900]
-extends = env_common_esp82xx
+extends = env_common_rx_esp82xx
 board = esp8285
 build_src_filter = 
-  ${env_common_esp82xx.build_src_filter} 
+  ${env_common_rx_esp82xx.build_src_filter} 
   +<modules/sx12xx-lib/src/sx127x.cpp>
 build_flags = 
   -DRX_ELRS_GENERIC_900_ESP8285
 
 
 [env:rx-generic-900-pa]
-extends = env_common_esp82xx
+extends = env_common_rx_esp82xx
 board = esp8285
 build_src_filter = 
-  ${env_common_esp82xx.build_src_filter} 
+  ${env_common_rx_esp82xx.build_src_filter} 
   +<modules/sx12xx-lib/src/sx127x.cpp>
 build_flags = 
   -DRX_ELRS_GENERIC_900_PA_ESP8285
 
 
 [env:rx-generic-2400]
-extends = env_common_esp82xx
+extends = env_common_rx_esp82xx
 board = esp8285
 build_src_filter = 
-  ${env_common_esp82xx.build_src_filter} 
+  ${env_common_rx_esp82xx.build_src_filter} 
   +<modules/sx12xx-lib/src/sx128x.cpp>
 build_flags = 
   -DRX_ELRS_GENERIC_2400_ESP8285
 
 
 [env:rx-generic-2400-pa]
-extends = env_common_esp82xx
+extends = env_common_rx_esp82xx
 board = esp8285
 build_src_filter = 
-  ${env_common_esp82xx.build_src_filter} 
+  ${env_common_rx_esp82xx.build_src_filter} 
   +<modules/sx12xx-lib/src/sx128x.cpp>
 build_flags = 
   -DRX_ELRS_GENERIC_2400_PA_ESP8285
@@ -108,7 +114,7 @@ board_build.f_cpu = 80000000L
 build_type = debug
 monitor_filters = esp8266_exception_decoder, default
 build_src_filter = 
-  ${env_common_esp82xx.build_src_filter} 
+  ${env_common_rx_esp82xx.build_src_filter} 
   +<modules/sx12xx-lib/src/sx127x.cpp>
 build_flags = 
   -DRX_DIYBOARD_900_ESP8266


### PR DESCRIPTION
@tmcadam @jlpoltrack 
for one (or both) of you to review and if good to merge :)

title says it

procedural notes (just to bring Tom in the loop):
 - I think any PR related to esp could start with "esp, " in the title :)
- since it's esp stuff one of you must approve. We started the habit to use the short lgtm to indicate approval (or one of you just merges, which is implict approval LOL)
- you will note that "merging" actually means "squash and merge". For explanation: I had set up the repo this way, since squash collapses all commits into one, otherwise we would have a pretty bloated commit history and it would be hard to follow the changes
- upon "squash and merge" you'll get a change to change the commit title. I'd like to pay a bit attention to it. Especially - following habits of ArduPilot - which I like - I like to start the title with e.g. "tools", "common", "rx", "tx", or "rx,tx", with the comment comma separated. This I really find helpfull. If this PR would be related to esp and rx code, I would have choosen a title "esp, rx, blabla". 

