### PR TITLE
esp, rx,tx, hal cleanify, sync with stm, move SYSTICK define, nfc

### DIFF
--- a/mLRS/Common/hal/esp-timer.h
+++ b/mLRS/Common/hal/esp-timer.h
@@ -14,6 +14,9 @@
 // SysTask & millis32()  functions
 //-------------------------------------------------------
 
+#define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
+
+
 volatile uint32_t doSysTask = 0;
 volatile uint32_t uwTick = 0;
 

--- a/mLRS/Common/hal/esp/rx-hal-dev-sx1278-esp8266.h
+++ b/mLRS/Common/hal/esp/rx-hal-dev-sx1278-esp8266.h
@@ -33,9 +33,6 @@
 
 //-- Timers, Timing, EEPROM, and such stuff
 
-#define SYSTICK_TIMESTEP          1000
-#define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
-
 #define EE_START_PAGE             0
 
 

--- a/mLRS/Common/hal/esp/rx-hal-generic-2400-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-2400-esp8285.h
@@ -17,9 +17,6 @@
 
 //-- Timers, Timing, EEPROM, and such stuff
 
-#define SYSTICK_TIMESTEP          1000
-#define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
-
 #define EE_START_PAGE             0
 
 

--- a/mLRS/Common/hal/esp/rx-hal-generic-2400-pa-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-2400-pa-esp8285.h
@@ -17,9 +17,6 @@
 
 //-- Timers, Timing, EEPROM, and such stuff
 
-#define SYSTICK_TIMESTEP          1000
-#define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
-
 #define EE_START_PAGE             0
 
 

--- a/mLRS/Common/hal/esp/rx-hal-generic-900-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-900-esp8285.h
@@ -17,9 +17,6 @@
 
 //-- Timers, Timing, EEPROM, and such stuff
 
-#define SYSTICK_TIMESTEP          1000
-#define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
-
 #define EE_START_PAGE             0
 
 

--- a/mLRS/Common/hal/esp/rx-hal-generic-900-pa-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-900-pa-esp8285.h
@@ -17,9 +17,6 @@
 
 //-- Timers, Timing, EEPROM, and such stuff
 
-#define SYSTICK_TIMESTEP          1000
-#define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
-
 #define EE_START_PAGE             0
 
 


### PR DESCRIPTION
moves SYSTICK defines from device hal files to hal.h and timer.h
this follows the cleanify for the stm32 code
it's nfc
tested to compile for all esp targets, and work for speedybee