### PR TITLE
dev-esp-rx-td, some tidies to branch dev-esp-rx-td, nfc

### DIFF
--- a/mLRS/Common/esp-lib/esp-delay.h
+++ b/mLRS/Common/esp-lib/esp-delay.h
@@ -20,7 +20,7 @@ IRAM_ATTR static inline void delay_us(uint32_t us)
     delayMicroseconds(us);
 }
 
-IRAM_ATTR static inline void delay_ms(uint32_t ms) 
+IRAM_ATTR static inline void delay_ms(uint32_t ms)
 {
     delay(ms);
 }
@@ -30,7 +30,7 @@ IRAM_ATTR static inline void delay_ms(uint32_t ms)
 // INIT routines
 //-------------------------------------------------------
 
-void delay_init(void) 
+void delay_init(void)
 {
     // not needed on the ESP chips, built into Arduino init
 }

--- a/mLRS/Common/esp-lib/esp-eeprom.h
+++ b/mLRS/Common/esp-lib/esp-eeprom.h
@@ -30,9 +30,9 @@ typedef enum {
     EE_STATUS_OK
 } EE_STATUS_ENUM;
 
-// ESP8266 has 4kb available for EEPROM. We need 3 pages, 2 for setup and 
-// 1 for the powerup counter. So best to keep page size to 3kb to let it 
-// fit in. 
+// ESP8266 has 4kb available for EEPROM. We need 3 pages, 2 for setup and
+// 1 for the powerup counter. So best to keep page size to 3kb to let it
+// fit in.
 #define EE_PAGE_SIZE  0x0400 // Page size = 1 KByte
 
 // EEPROM start address in Flash
@@ -145,14 +145,14 @@ uint32_t ToPageBaseAddress, ToPageEndAddress, FromPageBaseAddress, PageNo, adr;
         }
     }
     if (!EEPROM.commit()) {
-         status = EE_STATUS_FLASH_FAIL; 
+         status = EE_STATUS_FLASH_FAIL;
          goto QUICK_EXIT;
     }
     delay_ms(20);
     // Set ToPage status to EE_VALID_PAGE status
     ee_hal_programword(ToPageBaseAddress, EE_VALID_PAGE);
     if (!EEPROM.commit()) {
-         status = EE_STATUS_FLASH_FAIL; 
+         status = EE_STATUS_FLASH_FAIL;
          goto QUICK_EXIT;
     }
     delay_ms(20);
@@ -203,7 +203,7 @@ EE_STATUS_ENUM status;
 
 EE_STATUS_ENUM ee_format(void)
 {
-  EE_STATUS_ENUM status;
+EE_STATUS_ENUM status;
 
     //ee_hal_unlock();
 
@@ -221,7 +221,6 @@ QUICK_EXIT:
 
 EE_STATUS_ENUM ee_init(void)
 {
-
     EEPROM.begin(EE_PAGE_SIZE*2);
     EE_STATUS_ENUM status;
     uint32_t Page0Status, Page1Status;

--- a/mLRS/Common/esp-lib/esp-mcu.h
+++ b/mLRS/Common/esp-lib/esp-mcu.h
@@ -9,9 +9,9 @@
 #define ESPLIB_MCU_H
 
 
-void BootLoaderInit(void) 
+void BootLoaderInit(void)
 {
-    // Not sure what this one needs for the Arduino. 
+    // Not sure what this one needs for the Arduino.
     // Maybe a can be a hard reset using reset pin.
 };
 

--- a/mLRS/Common/esp-lib/esp-peripherals.h
+++ b/mLRS/Common/esp-lib/esp-peripherals.h
@@ -48,6 +48,7 @@
 #define IO_P38      38
 #define IO_P39      39
 
+
 typedef enum {
     IO_MODE_Z = 0,
     IO_MODE_INPUT_ANALOG,
@@ -87,20 +88,19 @@ void gpio_init(uint8_t GPIO_Pin, IOMODEENUM mode)
 
 GPIO_INLINE_FORCED void gpio_low(uint8_t GPIO_Pin)
 {
-#if defined(ESP32)
+#ifdef ESP32
     GPIO.out_w1tc = ((uint32_t)1 << GPIO_Pin);
-#elif defined(ESP8266)
+#elif defined ESP8266
     GPOC = (1 << GPIO_Pin);
-#endif 
-    
+#endif
 }
 
 
 GPIO_INLINE_FORCED void gpio_high(uint8_t GPIO_Pin)
 {
-#if defined(ESP32)
+#ifdef ESP32
     GPIO.out_w1ts = ((uint32_t)1 << GPIO_Pin);
-#elif defined(ESP8266)
+#elif defined ESP8266
     GPOS = (1 << GPIO_Pin);
 #endif
 }

--- a/mLRS/Common/esp-lib/esp-uartb.h
+++ b/mLRS/Common/esp-lib/esp-uartb.h
@@ -33,9 +33,9 @@ typedef enum {
 #define ESPLIB_UARTB_H
 
 
-#if defined(UARTB_USE_SERIAL)
+#ifdef UARTB_USE_SERIAL
 #define UARTB_SERIAL_NO Serial
-#elif defined(UARTB_USE_SERIAL1)
+#elif defined UARTB_USE_SERIAL1
 #define UARTB_SERIAL_NO Serial1
 #endif
 
@@ -86,13 +86,19 @@ void uartb_setprotocol(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM sto
     UARTB_SERIAL_NO.end();
     UARTB_SERIAL_NO.setRxBufferSize(UARTB_RXBUFSIZE);
     UARTB_SERIAL_NO.begin(baud);
-#if defined(ESP32) 
+#ifdef ESP32
     UARTB_SERIAL_NO.setRxFIFOFull(8);  // > 57600 baud sets to 120 which is too much, buffer only 127 bytes
     UARTB_SERIAL_NO.setRxTimeout(1);   // wait for 1 symbol (~11 bits) to trigger Rx ISR, default 2
-#endif    
+#endif
 }
 
 
-void uartb_init(void) {}               // nothing needed, we rely on setprotocol
+void uartb_init(void)
+{
+    // this is DIRTY:
+    // nothing done here, we rely on setprotocol
+    // TODO: get this right
+}
+
 
 #endif // ESPLIB_UARTB_H

--- a/mLRS/Common/hal/esp-glue.h
+++ b/mLRS/Common/hal/esp-glue.h
@@ -13,25 +13,25 @@
 #undef IRQHANDLER
 #define IRQHANDLER(__Declaration__)  extern "C" {IRAM_ATTR __Declaration__}
 
-#if defined(ESP32) 
+#ifdef ESP32
   static portMUX_TYPE esp32_spinlock = portMUX_INITIALIZER_UNLOCKED;
 #endif
 
 
 void __disable_irq(void)
 {
-#if defined(ESP32) 
+#ifdef ESP32
     taskENTER_CRITICAL(&esp32_spinlock);
-#elif defined(ESP8266)
+#elif defined ESP8266
     noInterrupts();
 #endif
 }
 
-void __enable_irq(void) 
+void __enable_irq(void)
 {
-#if defined(ESP32)
+#ifdef ESP32
     taskEXIT_CRITICAL(&esp32_spinlock);
-#elif defined(ESP8266)
+#elif defined ESP8266
     interrupts();
 #endif
 }

--- a/mLRS/Common/hal/esp-rxclock.h
+++ b/mLRS/Common/hal/esp-rxclock.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #define CLOCK_SHIFT_10US          100 // 75 // 100 // 1 ms
-#define CLOCK_CNT_1MS             100 // 10us interval 10us x 100 = 1000us        
+#define CLOCK_CNT_1MS             100 // 10us interval 10us x 100 = 1000us
 
 volatile bool doPostReceive;
 
@@ -33,18 +33,18 @@ void CLOCK_IRQHandler(void)
 
     // call HAL_IncTick every 1 ms
     if (CNT_10us == MS_C) {
-        MS_C = CNT_10us + CLOCK_CNT_1MS; 
+        MS_C = CNT_10us + CLOCK_CNT_1MS;
         HAL_IncTick();
     }
 
     // this is at about when RX was or was supposed to be received
-    if (CNT_10us == CCR1) { 
+    if (CNT_10us == CCR1) {
         CCR3 = CNT_10us + CLOCK_SHIFT_10US; // next doPostReceive
         CCR1 = CNT_10us + CLOCK_PERIOD_10US; // next tick
     }
 
     // this is 1 ms after RX was or was supposed to be received
-    if (CNT_10us == CCR3) { 
+    if (CNT_10us == CCR3) {
         doPostReceive = true;
     }
 
@@ -78,17 +78,17 @@ void RxClockBase::Init(uint16_t period_ms)
     CCR3 = CLOCK_SHIFT_10US;
     MS_C = CLOCK_CNT_1MS;
 
-    if (initialized) return; 
+    if (initialized) return;
 
     // Initialize the timer
-#if defined(ESP32)
+#ifdef ESP32
     hw_timer_t* timer0_cfg = nullptr;
-    timer0_cfg = timerBegin(0, 800, 1);  // Timer 0, APB clock is 80 Mhz | divide by 800 is 100 KHz / 10 us, count up    
+    timer0_cfg = timerBegin(0, 800, 1);  // Timer 0, APB clock is 80 Mhz | divide by 800 is 100 KHz / 10 us, count up
     timerAttachInterrupt(timer0_cfg, &CLOCK_IRQHandler, true);
     timerAlarmWrite(timer0_cfg, 1, true);
     timerAlarmEnable(timer0_cfg);
-#elif defined(ESP8266)
-    timer1_attachInterrupt(CLOCK_IRQHandler); 
+#elif defined ESP8266
+    timer1_attachInterrupt(CLOCK_IRQHandler);
     timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);
     timer1_write(50); // 5 MHz (5 ticks/us - 1677721.4 us max), 50 ticks = 10us
 #endif

--- a/mLRS/Common/hal/esp/rx-hal-dev-900-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-dev-900-esp32.h
@@ -35,6 +35,7 @@
 
 
 //-- SX1: SX12xx & SPI
+
 #define SPI_CS_IO                 IO_P18
 #define SPI_FREQUENCY             10000000L
 #define SPI_MISO                  IO_P19
@@ -53,7 +54,7 @@ void sx_init_gpio(void)
     // Fake ground for serial
     pinMode(13, OUTPUT);
     digitalWrite(13, LOW);
-} 
+}
 
 void sx_amp_transmit(void) {}
 void sx_amp_receive(void) {}
@@ -68,6 +69,7 @@ void sx_dio_exti_isr_clearflag(void) {}
 
 
 //-- Button
+
 #define BUTTON                    IO_P0
 
 void button_init(void)
@@ -82,7 +84,8 @@ IRAM_ATTR bool button_pressed(void)
 
 
 //-- LEDs
-#define LED_RED                   25
+
+#define LED_RED                   IO_P25
 
 void leds_init(void)
 {
@@ -95,6 +98,7 @@ void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER
+
 #define POWER_GAIN_DBM            0 // gain of a PA stage if present
 #define POWER_SX1276_MAX_DBM      SX1276_OUTPUT_POWER_MAX // maximum allowed sx power
 #define POWER_USE_DEFAULT_RFPOWER_CALC

--- a/mLRS/Common/hal/esp/rx-hal-dev-sx1278-esp8266.h
+++ b/mLRS/Common/hal/esp/rx-hal-dev-sx1278-esp8266.h
@@ -5,13 +5,11 @@
 //*******************************************************
 // hal
 //********************************************************
-
-//-------------------------------------------------------
 // ESP8266 DEVBOARD 900 RX
 //
 // Uses a Lolin Node MCU V3 ESP8266 Devboard and a SX1276 module
-// 
-// Could use other ESP8266 devboards 
+//
+// Could use other ESP8266 devboards
 //
 // https://www.aliexpress.com/item/1005005077804800.html
 // https://www.aliexpress.com/item/32962551530.html
@@ -23,8 +21,7 @@
 // D6  ->  MISO
 // D5  ->  SCK
 // D2  ->  REST
-// D1  ->  DIO0 
-//
+// D1  ->  DIO0
 //-------------------------------------------------------
 
 #define DEVICE_HAS_SINGLE_LED
@@ -42,20 +39,19 @@
 // UARTC = debug port
 
 #define UARTB_USE_SERIAL
-#define UARTB_BAUD                  RX_SERIAL_BAUDRATE
-#define UARTB_TXBUFSIZE             RX_SERIAL_TXBUFSIZE // 1024 // 512
-#define UARTB_RXBUFSIZE             RX_SERIAL_RXBUFSIZE // 1024 // 512
+#define UARTB_BAUD                RX_SERIAL_BAUDRATE
+#define UARTB_TXBUFSIZE           RX_SERIAL_TXBUFSIZE // 1024 // 512
+#define UARTB_RXBUFSIZE           RX_SERIAL_RXBUFSIZE // 1024 // 512
 
 #define UARTC_USE_SERIAL
-#define UARTC_BAUD                  115200
+#define UARTC_BAUD                115200
 
 
 //-- SX1: SX12xx & SPI
-#define SPI_CS_IO                 D8
+#define SPI_CS_IO                 IO_P8
 #define SPI_FREQUENCY             10000000L
-
-#define SX_RESET                  D2
-#define SX_DIO0                   D1
+#define SX_RESET                  IO_P2
+#define SX_DIO0                   IO_P1
 
 IRQHANDLER(void SX_DIO_EXTI_IRQHandler(void);)
 
@@ -64,7 +60,7 @@ void sx_init_gpio(void)
     pinMode(SX_RESET, OUTPUT);
     digitalWrite(SX_RESET, HIGH);
     pinMode(SX_DIO0, INPUT_PULLDOWN_16);
-} 
+}
 
 void sx_dio_enable_exti_isr(void)
 {
@@ -78,7 +74,8 @@ void sx_dio_exti_isr_clearflag(void) {}
 
 
 //-- Button
-#define BUTTON                    0
+
+#define BUTTON                    IO_P0
 
 void button_init(void)
 {
@@ -92,7 +89,8 @@ bool button_pressed(void)
 
 
 //-- LEDs
-#define LED_RED                   D4
+
+#define LED_RED                   IO_P4
 
 void leds_init(void)
 {
@@ -106,6 +104,7 @@ void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER
+
 #define POWER_GAIN_DBM            0 // gain of a PA stage if present
 #define POWER_SX1276_MAX_DBM      SX1276_OUTPUT_POWER_MAX // maximum allowed sx power
 #define POWER_USE_DEFAULT_RFPOWER_CALC

--- a/mLRS/Common/hal/esp/rx-hal-generic-2400-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-2400-esp8285.h
@@ -35,6 +35,7 @@
 
 
 //-- SX1: SX12xx & SPI
+
 #define SPI_CS_IO                 IO_P15
 #define SPI_FREQUENCY             16000000L
 #define SX_RESET                  IO_P2
@@ -68,6 +69,7 @@ void sx_dio_exti_isr_clearflag(void) {}
 
 
 //-- Button
+
 #define BUTTON                    IO_P0
 
 void button_init(void)
@@ -82,6 +84,7 @@ IRAM_ATTR bool button_pressed(void)
 
 
 //-- LEDs
+
 #define LED_RED                   IO_P16
 
 void leds_init(void)
@@ -95,6 +98,7 @@ void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER
+
 #define POWER_GAIN_DBM            0 // gain of a PA stage if present
 #define POWER_SX1280_MAX_DBM      SX1280_POWER_12p5_DBM  // maximum allowed sx power
 #define POWER_USE_DEFAULT_RFPOWER_CALC

--- a/mLRS/Common/hal/esp/rx-hal-generic-2400-pa-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-2400-pa-esp8285.h
@@ -35,6 +35,7 @@
 
 
 //-- SX1: SX12xx & SPI
+
 #define SPI_CS_IO                 IO_P15
 #define SPI_FREQUENCY             16000000L
 #define SX_RESET                  IO_P2
@@ -81,6 +82,7 @@ void sx_dio_exti_isr_clearflag(void) {}
 
 
 //-- Button
+
 #define BUTTON                    IO_P0
 
 void button_init(void)
@@ -95,6 +97,7 @@ IRAM_ATTR bool button_pressed(void)
 
 
 //-- LEDs
+
 #define LED_RED                   IO_P16
 
 void leds_init(void)
@@ -108,6 +111,7 @@ void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER
+
 #define POWER_GAIN_DBM            18 // gain of a PA stage if present
 #define POWER_SX1280_MAX_DBM      SX1280_POWER_3_DBM  // maximum allowed sx power
 #define POWER_USE_DEFAULT_RFPOWER_CALC

--- a/mLRS/Common/hal/esp/rx-hal-generic-2400-td-pa-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-2400-td-pa-esp32.h
@@ -2,13 +2,12 @@
 // Copyright (c) MLRS project
 // GPL3
 // https://www.gnu.org/licenses/gpl-3.0.de.html
-// OlliW @ www.olliw.eu
 //*******************************************************
 // hal
 //********************************************************
 
 //-------------------------------------------------------
-// GENERIC 2400 True Diversity PA Receiver ESP32
+// ESP32, ELRS GENERIC 2400 True Diversity PA RX
 //-------------------------------------------------------
 
 #define DEVICE_HAS_SINGLE_LED_RGB
@@ -20,6 +19,7 @@
 //-- Timers, Timing, EEPROM, and such stuff
 
 #define EE_START_PAGE             0 // 128 kB flash, 2 kB page
+
 
 //-- UARTS
 // UARTB = serial port
@@ -42,11 +42,9 @@
 #define SPI_MOSI                  IO_P32
 #define SPI_SCK                   IO_P25
 #define SPI_FREQUENCY             18000000L
-
 #define SX_BUSY                   IO_P36
 #define SX_DIO1                   IO_P37
 #define SX_RESET                  IO_P26
-
 #define SX_RX_EN                  IO_P10
 #define SX_TX_EN                  IO_P14
 
@@ -94,11 +92,9 @@ IRAM_ATTR inline void sx_dio_exti_isr_clearflag(void) {}
 //-- SX2: SX12xx & SPI
 
 #define SX2_CS_IO                 IO_P13
-
 #define SX2_BUSY                  IO_P39
 #define SX2_DIO1                  IO_P34
 #define SX2_RESET                 IO_P21
-
 #define SX2_RX_EN                 IO_P9
 #define SX2_TX_EN                 IO_P15
 
@@ -156,7 +152,7 @@ IRAM_ATTR inline void sx2_dio_exti_isr_clearflag(void) {}
 
 //-- Button
 
-#define BUTTON                    0
+#define BUTTON                    IO_P0
 
 void button_init(void)
 {
@@ -170,7 +166,7 @@ bool button_pressed(void)
 
 //-- LEDs
 #include <NeoPixelBus.h>
-#define LED_RED                    22
+#define LED_RED                    IO_P22
 bool ledRedState;
 bool ledGreenState;
 bool ledBlueState;
@@ -183,7 +179,7 @@ IRAM_ATTR void leds_init(void)
     ledRGB.Show();
 }
 
-IRAM_ATTR void led_red_off(void) 
+IRAM_ATTR void led_red_off(void)
 {
     if (!ledRedState) return;
     ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
@@ -191,7 +187,7 @@ IRAM_ATTR void led_red_off(void)
     ledRedState = 0;
 }
 
-IRAM_ATTR void led_red_on(void) 
+IRAM_ATTR void led_red_on(void)
 {
     if (ledRedState) return;
     ledRGB.SetPixelColor(0, RgbColor(255, 0, 0));
@@ -204,7 +200,7 @@ IRAM_ATTR void led_red_toggle(void)
     if (ledRedState) { led_red_off(); } else { led_red_on(); }
 }
 
-IRAM_ATTR void led_green_off(void) 
+IRAM_ATTR void led_green_off(void)
 {
     if (!ledGreenState) return;
     ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
@@ -212,7 +208,7 @@ IRAM_ATTR void led_green_off(void)
     ledGreenState = 0;
 }
 
-IRAM_ATTR void led_green_on(void) 
+IRAM_ATTR void led_green_on(void)
 {
     if (ledGreenState) return;
     ledRGB.SetPixelColor(0, RgbColor(0, 255, 0));
@@ -225,7 +221,7 @@ IRAM_ATTR void led_green_toggle(void)
     if (ledGreenState) { led_green_off(); } else { led_green_on(); }
 }
 
-IRAM_ATTR void led_blue_off(void) 
+IRAM_ATTR void led_blue_off(void)
 {
     if (!ledBlueState) return;
     ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
@@ -233,7 +229,7 @@ IRAM_ATTR void led_blue_off(void)
     ledBlueState = 0;
 }
 
-IRAM_ATTR void led_blue_on(void) 
+IRAM_ATTR void led_blue_on(void)
 {
     if (ledBlueState) return;
     ledRGB.SetPixelColor(0, RgbColor(0, 0, 255));
@@ -245,6 +241,7 @@ IRAM_ATTR void led_blue_toggle(void)
 {
     if (ledBlueState) { led_blue_off(); } else { led_blue_on(); }
 }
+
 
 //-- POWER
 

--- a/mLRS/Common/hal/esp/rx-hal-generic-2400-td-pa-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-2400-td-pa-esp32.h
@@ -110,12 +110,12 @@ void sx2_init_gpio(void)
     gpio_init(SX2_RESET, IO_MODE_OUTPUT_PP_LOW);
 }
 
-IRAM_ATTR static inline void spi2_select(void)
+IRAM_ATTR static inline void spib_select(void)
 {
     gpio_low(SX2_CS_IO);
 }
 
-IRAM_ATTR static inline void spi2_deselect(void)
+IRAM_ATTR static inline void spib_deselect(void)
 {
     gpio_high(SX2_CS_IO);
 }

--- a/mLRS/Common/hal/esp/rx-hal-generic-900-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-900-esp8285.h
@@ -35,6 +35,7 @@
 
 
 //-- SX1: SX12xx & SPI
+
 #define SPI_CS_IO                 IO_P15
 #define SPI_FREQUENCY             10000000L
 #define SX_RESET                  IO_P2
@@ -47,7 +48,7 @@ void sx_init_gpio(void)
 {
     gpio_init(SX_DIO0, IO_MODE_INPUT_ANALOG);
     gpio_init(SX_RESET, IO_MODE_OUTPUT_PP_HIGH);
-} 
+}
 
 void sx_amp_transmit(void) {}
 void sx_amp_receive(void) {}
@@ -62,6 +63,7 @@ void sx_dio_exti_isr_clearflag(void) {}
 
 
 //-- Button
+
 #define BUTTON                    IO_P0
 
 void button_init(void)
@@ -76,6 +78,7 @@ IRAM_ATTR bool button_pressed(void)
 
 
 //-- LEDs
+
 #define LED_RED                   IO_P16
 
 void leds_init(void)
@@ -89,6 +92,7 @@ void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER
+
 #define POWER_GAIN_DBM            0 // gain of a PA stage if present
 #define POWER_SX1276_MAX_DBM      SX1276_OUTPUT_POWER_MAX // maximum allowed sx power
 #define POWER_USE_DEFAULT_RFPOWER_CALC

--- a/mLRS/Common/hal/esp/rx-hal-generic-900-pa-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-900-pa-esp8285.h
@@ -35,6 +35,7 @@
 
 
 //-- SX1: SX12xx & SPI
+
 #define SPI_CS_IO                 IO_P15
 #define SPI_FREQUENCY             10000000L
 #define SX_RESET                  IO_P2
@@ -62,6 +63,7 @@ void sx_dio_exti_isr_clearflag(void) {}
 
 
 //-- Button
+
 #define BUTTON                    IO_P0
 
 void button_init(void)
@@ -76,6 +78,7 @@ IRAM_ATTR bool button_pressed(void)
 
 
 //-- LEDs
+
 #define LED_RED                   IO_P16
 
 void leds_init(void)
@@ -89,6 +92,7 @@ void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER
+
 #define POWER_GAIN_DBM            13 // gain of a PA stage if present
 #define POWER_SX1276_MAX_DBM      SX1276_OUTPUT_POWER_MAX // maximum allowed sx power
 #define POWER_USE_DEFAULT_RFPOWER_CALC

--- a/mLRS/Common/hal/hal.h
+++ b/mLRS/Common/hal/hal.h
@@ -375,7 +375,7 @@ Note: Some "high-level" features are set for each device in the device_conf.h fi
   #define SX_DRIVER Sx128xDriver
 #endif
 
-#if defined DEVICE_HAS_DIVERSITY
+#if defined DEVICE_HAS_DIVERSITY || defined DEVICE_HAS_DIVERSITY_SINGLE_SPI
   #ifdef DEVICE_HAS_SX126x
     #define SX2_DRIVER Sx126xDriver2
   #elif defined DEVICE_HAS_SX127x
@@ -383,8 +383,6 @@ Note: Some "high-level" features are set for each device in the device_conf.h fi
   #else
     #define SX2_DRIVER Sx128xDriver2
   #endif
-#elif defined DEVICE_HAS_DIVERSITY_SINGLE_SPI
-  #define SX2_DRIVER Sx128xDriver2onSpi1
 #elif defined DEVICE_HAS_DUAL_SX126x_SX128x
   #define SX2_DRIVER Sx128xDriver2
 #elif defined DEVICE_HAS_DUAL_SX126x_SX126x
@@ -394,7 +392,8 @@ Note: Some "high-level" features are set for each device in the device_conf.h fi
 #endif
 
 
-#if defined DEVICE_HAS_DIVERSITY || defined DEVICE_HAS_DIVERSITY_SINGLE_SPI || defined DEVICE_HAS_DUAL_SX126x_SX128x || defined DEVICE_HAS_DUAL_SX126x_SX126x
+#if defined DEVICE_HAS_DIVERSITY || defined DEVICE_HAS_DIVERSITY_SINGLE_SPI || \
+    defined DEVICE_HAS_DUAL_SX126x_SX128x || defined DEVICE_HAS_DUAL_SX126x_SX126x
   #define USE_SX2
 #endif
 

--- a/mLRS/CommonRx/mlrs-rx.cpp
+++ b/mLRS/CommonRx/mlrs-rx.cpp
@@ -29,7 +29,7 @@ v0.0.00:
 #include "../Common/common_conf.h"
 #include "../Common/common_types.h"
 
-#if defined(ESP8266) || defined(ESP32)
+#if defined ESP8266 || defined ESP32
 
 #include "../Common/hal/esp-glue.h"
 #include "../modules/stm32ll-lib/src/stdstm32.h"

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,13 +23,14 @@ monitor_speed = 115200
 platform = espressif8266@4.2.1
 board_build.f_cpu = 160000000L
 build_type = release
+build_flags = -Os
 
 [env_common_esp32]
 platform = espressif32@6.6.0
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 build_type = release
-build_flags = 
+build_flags =
   -D CONFIG_DISABLE_HAL_LOCKS=1
   -D CONFIG_GPIO_CTRL_FUNC_IN_IRAM=y
   -D CONFIG_GPTIMER_CTRL_FUNC_IN_IRAM=y
@@ -54,7 +55,6 @@ build_src_filter =
   +<Common/libs/filters.cpp>
   +<modules/stm32ll-lib/src/stdstm32.c>
 
-
 [env_common_rx_esp82xx]
 extends = env_common_esp82xx
 build_src_filter = ${env_common_rx.build_src_filter}
@@ -73,97 +73,109 @@ build_src_filter = ${env_common_rx.build_src_filter}
 [env:rx-generic-900]
 extends = env_common_rx_esp82xx
 board = esp8285
-build_src_filter = 
-  ${env_common_rx_esp82xx.build_src_filter} 
+build_src_filter =
+  ${env_common_rx_esp82xx.build_src_filter}
   +<modules/sx12xx-lib/src/sx127x.cpp>
-build_flags = 
-  -DRX_ELRS_GENERIC_900_ESP8285
+build_flags =
+  ${env_common_rx_esp82xx.build_flags}
+  -D RX_ELRS_GENERIC_900_ESP8285
 
 
 [env:rx-generic-900-pa]
 extends = env_common_rx_esp82xx
 board = esp8285
-build_src_filter = 
-  ${env_common_rx_esp82xx.build_src_filter} 
+build_src_filter =
+  ${env_common_rx_esp82xx.build_src_filter}
   +<modules/sx12xx-lib/src/sx127x.cpp>
-build_flags = 
-  -DRX_ELRS_GENERIC_900_PA_ESP8285
+build_flags =
+  ${env_common_rx_esp82xx.build_flags}
+  -D RX_ELRS_GENERIC_900_PA_ESP8285
 
 
 [env:rx-generic-2400]
 extends = env_common_rx_esp82xx
 board = esp8285
-build_src_filter = 
-  ${env_common_rx_esp82xx.build_src_filter} 
+build_src_filter =
+  ${env_common_rx_esp82xx.build_src_filter}
   +<modules/sx12xx-lib/src/sx128x.cpp>
-build_flags = 
-  -DRX_ELRS_GENERIC_2400_ESP8285
+build_flags =
+  ${env_common_rx_esp82xx.build_flags}
+  -D RX_ELRS_GENERIC_2400_ESP8285
 
 
 [env:rx-generic-2400-pa]
 extends = env_common_rx_esp82xx
 board = esp8285
-build_src_filter = 
-  ${env_common_rx_esp82xx.build_src_filter} 
+build_src_filter =
+  ${env_common_rx_esp82xx.build_src_filter}
   +<modules/sx12xx-lib/src/sx128x.cpp>
-build_flags = 
-  -DRX_ELRS_GENERIC_2400_PA_ESP8285
+build_flags =
+  ${env_common_rx_esp32.build_flags}
+  -D RX_ELRS_GENERIC_2400_PA_ESP8285
+
 
 [env:rx-generic-2400-td-pa]
 extends = env_common_rx_esp32
 board = pico32
-lib_deps = 
+lib_deps =
   makuna/NeoPixelBus@^2.7.9
-build_src_filter = 
+build_src_filter =
   ${env_common_rx_esp32.build_src_filter}
   +<modules/sx12xx-lib/src/sx128x.cpp>
-build_flags = 
-  -DRX_GENERIC_2400_TD_PA_ESP32
-  ${env_common_esp32.build_flags}
+build_flags =
+  ${env_common_rx_esp32.build_flags}
+  -D RX_GENERIC_2400_TD_PA_ESP32
 
 
 ; ELRS boards
 
 [env:rx-bayck-nano-pro-900]
 extends = env:rx-generic-900-pa
-build_flags = 
-  -DRX_ELRS_BAYCK_NANO_PRO_900_ESP8285
+build_flags =
+  ${env_common_rx_esp82xx.build_flags}
+  -D RX_ELRS_BAYCK_NANO_PRO_900_ESP8285
+
 
 [env:rx-speedybee-nano-2400]
 extends = env:rx-generic-2400-pa
-build_flags = 
-  -DRX_ELRS_SPEEDYBEE_NANO_2400_ESP8285
+build_flags =
+  ${env_common_rx_esp82xx.build_flags}
+  -D RX_ELRS_SPEEDYBEE_NANO_2400_ESP8285
+
 
 [env:rx-betafpv-superd-2400]
 extends = env:rx-generic-2400-td-pa
-build_flags = 
-  -DRX_ELRS_BETAFPV_SUPERD_2400_ESP32
-  -DSX_USE_REGULATOR_MODE_DCDC
-  -DSX2_USE_REGULATOR_MODE_DCDC
-  ${env_common_esp32.build_flags}
+build_flags =
+  ${env_common_rx_esp32.build_flags}
+  -D RX_ELRS_BETAFPV_SUPERD_2400_ESP32
+  -D SX_USE_REGULATOR_MODE_DCDC
+  -D SX2_USE_REGULATOR_MODE_DCDC
 
 
 ; ESP DIY boards
 
 [env:rx-diyboard-900]
-extends = env_common_esp82xx
+extends = env_common_rx_esp82xx
 board = nodemcuv2
 board_build.f_cpu = 80000000L
 build_type = debug
 monitor_filters = esp8266_exception_decoder, default
-build_src_filter = 
-  ${env_common_rx_esp82xx.build_src_filter} 
+build_src_filter =
+  ${env_common_rx_esp82xx.build_src_filter}
   +<modules/sx12xx-lib/src/sx127x.cpp>
-build_flags = 
-  -DRX_DIYBOARD_900_ESP8266
+build_flags =
+  ${env_common_rx_esp82xx.build_flags}
+  -D RX_DIYBOARD_900_ESP8266
+
 
 [env:rx-dev-900-esp32]
-extends = env_common_esp32
+extends = env_common_rx_esp32
 board = heltec_wireless_stick_lite
 monitor_filters = esp32_exception_decoder, default, time
-build_src_filter = 
+build_src_filter =
   ${env_common_rx_esp32.build_src_filter}
   +<modules/sx12xx-lib/src/sx127x.cpp>
-build_flags = 
-  -DRX_DEV_900_ESP32
+build_flags =
   ${env_common_esp32.build_flags}
+  -D RX_DEV_900_ESP32
+


### PR DESCRIPTION
this does some tidies and cleanups
they all should be nfc
the large majority are really just formatting, blanks, etc.
the major changes were done to the use of DIVERSITY_SINGLE_SPI. It seems to me the driver had been essentially identical and needed only minor change, so I put it into one driver.
tested to not have changed the working on a RP4TD