### PR TITLE
dev-esp-rx-td, more tidies, mostly nfc

### DIFF
--- a/mLRS/Common/esp-lib/esp-peripherals.h
+++ b/mLRS/Common/esp-lib/esp-peripherals.h
@@ -93,9 +93,8 @@ GPIO_INLINE_FORCED void gpio_low(uint8_t GPIO_Pin)
 #elif defined ESP8266  // special handling needed for pin 16
     if (GPIO_Pin < 16) {
         GPOC = (1 << GPIO_Pin);
-    }
-    else if (GPIO_Pin == 16) {
-        GP16O &= ~1;
+    } else if (GPIO_Pin == 16) {
+        GP16O &=~ 1;
     }
 #endif
 }
@@ -106,10 +105,9 @@ GPIO_INLINE_FORCED void gpio_high(uint8_t GPIO_Pin)
 #ifdef ESP32
     GPIO.out_w1ts = ((uint32_t)1 << GPIO_Pin);
 #elif defined ESP8266 // special handling needed for pin 16
-    if (GPIO_Pin < 16){
+    if (GPIO_Pin < 16) {
         GPOS = (1 << GPIO_Pin);
-    }
-    else if (GPIO_Pin == 16) {
+    } else if (GPIO_Pin == 16) {
         GP16O |= 1;
     }
 #endif

--- a/mLRS/Common/esp-lib/esp-spi.h
+++ b/mLRS/Common/esp-lib/esp-spi.h
@@ -95,8 +95,8 @@ void spi_init(void)
 #elif defined ESP8266
     SPI.begin();
 #endif
-    SPI.setBitOrder(SPI_MSBFIRST);
     SPI.setFrequency(SPI_FREQUENCY);
+    SPI.setBitOrder(SPI_MSBFIRST);
     SPI.setDataMode(SPI_MODE0);
 }
 

--- a/mLRS/Common/esp-lib/esp-uartb.h
+++ b/mLRS/Common/esp-lib/esp-uartb.h
@@ -40,14 +40,14 @@ typedef enum {
 #endif
 
 
-IRAM_ATTR inline uint16_t uartb_putc(char c)
+IRAM_ATTR static inline uint16_t uartb_putc(char c)
 {
     UARTB_SERIAL_NO.write(c);
     return 1;
 }
 
 
-IRAM_ATTR inline char uartb_getc(void)
+IRAM_ATTR static inline char uartb_getc(void)
 {
     return (char)UARTB_SERIAL_NO.read();
 }
@@ -65,7 +65,7 @@ IRAM_ATTR static inline void uartb_tx_flush(void)
 }
 
 
-IRAM_ATTR inline uint16_t uartb_rx_bytesavailable(void)
+IRAM_ATTR static inline uint16_t uartb_rx_bytesavailable(void)
 {
     return (UARTB_SERIAL_NO.available() > 0) ? UARTB_SERIAL_NO.available() : 0;
 }
@@ -97,6 +97,10 @@ void uartb_init(void)
 {
     UARTB_SERIAL_NO.end();
     UARTB_SERIAL_NO.begin(RX_SERIAL_BAUDRATE);
+#ifdef ESP32
+    UARTB_SERIAL_NO.setRxFIFOFull(8);
+    UARTB_SERIAL_NO.setRxTimeout(1);
+#endif
 }
 
 

--- a/mLRS/Common/hal/device_conf.h
+++ b/mLRS/Common/hal/device_conf.h
@@ -369,14 +369,14 @@ The default selection of frequency bands can be overruled by feature defines.
   #define FREQUENCY_BAND_2P4_GHZ
 #endif
 
-#ifdef RX_GENERIC_2400_TD_PA_ESP32
+#ifdef RX_ELRS_GENERIC_2400_TD_PA_ESP32
   #define DEVICE_NAME "GENERIC 2400 TD PA"
   #define DEVICE_IS_RECEIVER
   #define DEVICE_HAS_SX128x
   #define FREQUENCY_BAND_2P4_GHZ
 #endif
 
-//-- ELRS selected Devices
+//-- ELRS Selected Devices
 
 #ifdef RX_ELRS_BAYCK_NANO_PRO_900_ESP8285
   #define DEVICE_NAME "BAYCK NANO PRO 900"
@@ -388,6 +388,13 @@ The default selection of frequency bands can be overruled by feature defines.
 
 #ifdef RX_ELRS_SPEEDYBEE_NANO_2400_ESP8285
   #define DEVICE_NAME "SPEEDYBEE NANO 2.4G"
+  #define DEVICE_IS_RECEIVER
+  #define DEVICE_HAS_SX128x
+  #define FREQUENCY_BAND_2P4_GHZ
+#endif
+
+#ifdef RX_ELRS_RADIOMASTER_RP4TD_2400_ESP32
+  #define DEVICE_NAME "RM RP4TD 2.4G"
   #define DEVICE_IS_RECEIVER
   #define DEVICE_HAS_SX128x
   #define FREQUENCY_BAND_2P4_GHZ

--- a/mLRS/Common/hal/esp-glue.h
+++ b/mLRS/Common/hal/esp-glue.h
@@ -10,12 +10,14 @@
 
 #define __NOP() _NOP()
 
+
 #undef IRQHANDLER
 #define IRQHANDLER(__Declaration__)  extern "C" {IRAM_ATTR __Declaration__}
 
 
 void __disable_irq(void) {}
 void __enable_irq(void) {}
+
 
 void hal_init(void) {} // nothing to do
 

--- a/mLRS/Common/hal/esp/rx-hal-dev-900-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-dev-900-esp32.h
@@ -52,8 +52,7 @@ void sx_init_gpio(void)
     gpio_init(SX_RESET, IO_MODE_OUTPUT_PP_HIGH);
 
     // Fake ground for serial
-    pinMode(13, OUTPUT);
-    digitalWrite(13, LOW);
+    gpio_init(13, IO_MODE_OUTPUT_PP_LOW);
 }
 
 void sx_amp_transmit(void) {}

--- a/mLRS/Common/hal/esp/rx-hal-dev-sx1278-esp8266.h
+++ b/mLRS/Common/hal/esp/rx-hal-dev-sx1278-esp8266.h
@@ -48,6 +48,7 @@
 
 
 //-- SX1: SX12xx & SPI
+
 #define SPI_CS_IO                 IO_P8
 #define SPI_FREQUENCY             10000000L
 #define SX_RESET                  IO_P2
@@ -57,8 +58,7 @@ IRQHANDLER(void SX_DIO_EXTI_IRQHandler(void);)
 
 void sx_init_gpio(void)
 {
-    pinMode(SX_RESET, OUTPUT);
-    digitalWrite(SX_RESET, HIGH);
+    gpio_init(SX_RESET, IO_MODE_OUTPUT_PP_HIGH);
     pinMode(SX_DIO0, INPUT_PULLDOWN_16);
 }
 
@@ -79,7 +79,7 @@ void sx_dio_exti_isr_clearflag(void) {}
 
 void button_init(void)
 {
-    pinMode(BUTTON, INPUT_PULLUP);
+    gpio_init(BUTTON, IO_MODE_INPUT_PU);
 }
 
 bool button_pressed(void)
@@ -94,8 +94,7 @@ bool button_pressed(void)
 
 void leds_init(void)
 {
-    pinMode(LED_RED, OUTPUT);
-    digitalWrite(LED_RED, HIGH);
+    gpio_init(LED_RED, IO_MODE_OUTPUT_PP_HIGH);    
 }
 
 void led_red_off(void) { gpio_high(LED_RED); }

--- a/mLRS/Common/hal/esp/rx-hal-generic-2400-td-pa-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-2400-td-pa-esp32.h
@@ -18,7 +18,7 @@
 
 //-- Timers, Timing, EEPROM, and such stuff
 
-#define EE_START_PAGE             0 // 128 kB flash, 2 kB page
+#define EE_START_PAGE             0
 
 
 //-- UARTS
@@ -156,13 +156,14 @@ IRAM_ATTR inline void sx2_dio_exti_isr_clearflag(void) {}
 
 void button_init(void)
 {
-    pinMode(BUTTON, INPUT_PULLUP);
+    gpio_init(BUTTON, IO_MODE_INPUT_PU);
 }
 
 bool button_pressed(void)
 {
     return gpio_read_activelow(BUTTON) ? true : false;
 }
+
 
 //-- LEDs
 #include <NeoPixelBus.h>

--- a/mLRS/Common/hal/hal.h
+++ b/mLRS/Common/hal/hal.h
@@ -241,11 +241,11 @@ Note: Some "high-level" features are set for each device in the device_conf.h fi
 #include "esp/rx-hal-generic-2400-pa-esp8285.h"
 #endif
 
-#ifdef RX_GENERIC_2400_TD_PA_ESP32
+#ifdef RX_ELRS_GENERIC_2400_TD_PA_ESP32
 #include "esp/rx-hal-generic-2400-td-pa-esp32.h"
 #endif
 
-//-- ELRS selected Devices
+//-- ELRS Selected Devices
 
 #ifdef RX_ELRS_BAYCK_NANO_PRO_900_ESP8285
 #include "esp/rx-hal-generic-900-pa-esp8285.h"
@@ -253,6 +253,10 @@ Note: Some "high-level" features are set for each device in the device_conf.h fi
 
 #ifdef RX_ELRS_SPEEDYBEE_NANO_2400_ESP8285
 #include "esp/rx-hal-generic-2400-pa-esp8285.h"
+#endif
+
+#ifdef RX_ELRS_RADIOMASTER_RP4TD_2400_ESP32
+#include "esp/rx-hal-generic-2400-td-pa-esp32.h"
 #endif
 
 #ifdef RX_ELRS_BETAFPV_SUPERD_2400_ESP32

--- a/mLRS/Common/leds.h
+++ b/mLRS/Common/leds.h
@@ -29,32 +29,32 @@ class tLEDs
     void Tick_ms(bool connected)
     {
 #ifdef DEVICE_HAS_SINGLE_LED
-    if (!is_in_bind) {
-        DECc(blink, SYSTICK_DELAY_MS(500));
-    } else {
-        DECc(blink, SYSTICK_DELAY_MS(100));
-    }
+        if (!is_in_bind) {
+            DECc(blink, SYSTICK_DELAY_MS(500));
+        } else {
+            DECc(blink, SYSTICK_DELAY_MS(100));
+        }
 
-    if (connected && !is_in_bind) {
-        led_red_on();
-    } else if (!blink) {
-        led_red_toggle();
-    }
+        if (connected && !is_in_bind) {
+            led_red_on();
+        } else if (!blink) {
+            led_red_toggle();
+        }
 #elif defined DEVICE_HAS_SINGLE_LED_RGB 
-    if (connected) {
-        DECc(blink, SYSTICK_DELAY_MS(500));
-    } else {
-        DECc(blink, SYSTICK_DELAY_MS(200));
-    }
+        if (connected) {
+            DECc(blink, SYSTICK_DELAY_MS(500));
+        } else {
+            DECc(blink, SYSTICK_DELAY_MS(200));
+        }
 
-    if (is_in_bind) {
-        if (!blink) { led_blue_toggle(); }
-    } else
-    if (connected) {
-        if (!blink) led_green_toggle();
-    } else {
-        if (!blink) led_red_toggle();
-    }
+        if (is_in_bind) {
+            if (!blink) { led_blue_toggle(); }
+        } else
+        if (connected) {
+            if (!blink) led_green_toggle();
+        } else {
+            if (!blink) led_red_toggle();
+        }
 #else
         if (connected) {
             DECc(blink, SYSTICK_DELAY_MS(500));

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,7 +40,7 @@ build_flags =
   -O2
 build_unflags = -Os
 
-; RX
+;-- RX --
 
 [env_common_rx]
 build_src_filter =
@@ -68,7 +68,7 @@ build_src_filter = ${env_common_rx.build_src_filter}
 ; target boards
 ;--------------------
 
-; ELRS generic layouts
+;-- ELRS generic layouts --
 
 [env:rx-generic-900]
 extends = env_common_rx_esp82xx
@@ -110,7 +110,7 @@ build_src_filter =
   ${env_common_rx_esp82xx.build_src_filter}
   +<modules/sx12xx-lib/src/sx128x.cpp>
 build_flags =
-  ${env_common_rx_esp32.build_flags}
+  ${env_common_rx_esp82xx.build_flags}
   -D RX_ELRS_GENERIC_2400_PA_ESP8285
 
 
@@ -124,10 +124,10 @@ build_src_filter =
   +<modules/sx12xx-lib/src/sx128x.cpp>
 build_flags =
   ${env_common_rx_esp32.build_flags}
-  -D RX_GENERIC_2400_TD_PA_ESP32
+  -D RX_ELRS_GENERIC_2400_TD_PA_ESP32
 
 
-; ELRS boards
+;-- selected ELRS boards --
 
 [env:rx-bayck-nano-pro-900]
 extends = env:rx-generic-900-pa
@@ -143,6 +143,13 @@ build_flags =
   -D RX_ELRS_SPEEDYBEE_NANO_2400_ESP8285
 
 
+[env:rx-radiomaster-rp4td-2400]
+extends = env:rx-generic-2400-td-pa
+build_flags =
+  ${env_common_rx_esp32.build_flags}
+  -D RX_ELRS_RADIOMASTER_RP4TD_2400_ESP32
+
+
 [env:rx-betafpv-superd-2400]
 extends = env:rx-generic-2400-td-pa
 build_flags =
@@ -152,7 +159,7 @@ build_flags =
   -D SX2_USE_REGULATOR_MODE_DCDC
 
 
-; ESP DIY boards
+;-- ESP DIY boards --
 
 [env:rx-diyboard-900]
 extends = env_common_rx_esp82xx


### PR DESCRIPTION
title says it, more tidies from my side
- the large majority are nfc, and really just formatting
- in esp-uartb.h I have replaced some inline by static inline (Note: inline is useless, it needs to be static inline)
- in platformio there was a bug, in there a esp826xx target was taking esp build flags
- added RM RP4TD as selected target device
- changed things in the dev targets, hope I got that correct