### PR TITLE
dev-esp-rx-td, hopefully last set of tidies II

### DIFF
--- a/mLRS/Common/hal/esp-glue.h
+++ b/mLRS/Common/hal/esp-glue.h
@@ -19,11 +19,6 @@ void __disable_irq(void) {}
 void __enable_irq(void) {}
 
 
-void hal_init(void)
-{
-    // nothing to do
-}
-
 
 // setup(), loop() streamlining between Arduino/STM code
 uint8_t restart_controller = 0;

--- a/mLRS/Common/hal/esp/rx-hal-dev-900-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-dev-900-esp32.h
@@ -71,7 +71,7 @@ void button_init(void)
     gpio_init(BUTTON, IO_MODE_INPUT_PU);
 }
 
-bool button_pressed(void)
+IRAM_ATTR bool button_pressed(void)
 {
     return gpio_read_activelow(BUTTON) ? true : false;
 }
@@ -86,9 +86,9 @@ void leds_init(void)
     gpio_init(LED_RED, IO_MODE_OUTPUT_PP_LOW);
 }
 
-IRAM_ATTR static inline void led_red_off(void) { gpio_low(LED_RED); }
-IRAM_ATTR static inline void led_red_on(void) { gpio_high(LED_RED); }
-IRAM_ATTR static inline void led_red_toggle(void) { gpio_toggle(LED_RED); }
+IRAM_ATTR void led_red_off(void) { gpio_low(LED_RED); }
+IRAM_ATTR void led_red_on(void) { gpio_high(LED_RED); }
+IRAM_ATTR void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER

--- a/mLRS/Common/hal/esp/rx-hal-dev-sx1278-esp8266.h
+++ b/mLRS/Common/hal/esp/rx-hal-dev-sx1278-esp8266.h
@@ -57,13 +57,14 @@ void sx_init_gpio(void)
     pinMode(SX_DIO0, INPUT_PULLDOWN_16);
 }
 
+void sx_amp_transmit(void) {}
+void sx_amp_receive(void) {}
+
 void sx_dio_enable_exti_isr(void)
 {
     attachInterrupt(SX_DIO0, SX_DIO_EXTI_IRQHandler, RISING);
 }
 
-void sx_amp_transmit(void) {}
-void sx_amp_receive(void) {}
 void sx_dio_init_exti_isroff(void) {}
 void sx_dio_exti_isr_clearflag(void) {}
 
@@ -77,7 +78,7 @@ void button_init(void)
     gpio_init(BUTTON, IO_MODE_INPUT_PU);
 }
 
-bool button_pressed(void)
+IRAM_ATTR bool button_pressed(void)
 {
     return (digitalRead(BUTTON) == HIGH) ? false : true;
 }
@@ -92,9 +93,9 @@ void leds_init(void)
     gpio_init(LED_RED, IO_MODE_OUTPUT_PP_HIGH);
 }
 
-void led_red_off(void) { gpio_high(LED_RED); }
-void led_red_on(void) { gpio_low(LED_RED); }
-void led_red_toggle(void) { gpio_toggle(LED_RED); }
+IRAM_ATTR void led_red_off(void) { gpio_high(LED_RED); }
+IRAM_ATTR void led_red_on(void) { gpio_low(LED_RED); }
+IRAM_ATTR void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER

--- a/mLRS/Common/hal/esp/rx-hal-generic-2400-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-2400-esp8285.h
@@ -46,7 +46,7 @@ void sx_init_gpio(void)
     gpio_init(SX_RESET, IO_MODE_OUTPUT_PP_HIGH);
 }
 
-IRAM_ATTR bool sx_busy_read(void)
+IRAM_ATTR static inline bool sx_busy_read(void)
 {
     return (gpio_read_activehigh(SX_BUSY)) ? true : false;
 }
@@ -54,7 +54,7 @@ IRAM_ATTR bool sx_busy_read(void)
 void sx_amp_transmit(void) {}
 void sx_amp_receive(void) {}
 
-IRAM_ATTR void sx_dio_enable_exti_isr(void)
+void sx_dio_enable_exti_isr(void)
 {
     attachInterrupt(SX_DIO1, SX_DIO_EXTI_IRQHandler, RISING);
 }
@@ -87,9 +87,9 @@ void leds_init(void)
     gpio_init(LED_RED, IO_MODE_OUTPUT_PP_HIGH);
 }
 
-void led_red_off(void) { gpio_high(LED_RED); }
-void led_red_on(void) { gpio_low(LED_RED); }
-void led_red_toggle(void) { gpio_toggle(LED_RED); }
+IRAM_ATTR void led_red_off(void) { gpio_high(LED_RED); }
+IRAM_ATTR void led_red_on(void) { gpio_low(LED_RED); }
+IRAM_ATTR void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER

--- a/mLRS/Common/hal/esp/rx-hal-generic-2400-pa-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-2400-pa-esp8285.h
@@ -50,18 +50,18 @@ void sx_init_gpio(void)
     gpio_init(SX_RESET, IO_MODE_OUTPUT_PP_HIGH);
 }
 
-IRAM_ATTR bool sx_busy_read(void)
+IRAM_ATTR static inline bool sx_busy_read(void)
 {
     return (gpio_read_activehigh(SX_BUSY)) ? true : false;
 }
 
-IRAM_ATTR void sx_amp_transmit(void)
+IRAM_ATTR static inline void sx_amp_transmit(void)
 {
     gpio_low(SX_RX_EN);
     gpio_high(SX_TX_EN);
 }
 
-IRAM_ATTR void sx_amp_receive(void)
+IRAM_ATTR static inline void sx_amp_receive(void)
 {
     gpio_low(SX_TX_EN);
     gpio_high(SX_RX_EN);
@@ -100,9 +100,9 @@ void leds_init(void)
     gpio_init(LED_RED, IO_MODE_OUTPUT_PP_LOW);
 }
 
-void led_red_off(void) { gpio_low(LED_RED); }
-void led_red_on(void) { gpio_high(LED_RED); }
-void led_red_toggle(void) { gpio_toggle(LED_RED); }
+IRAM_ATTR void led_red_off(void) { gpio_low(LED_RED); }
+IRAM_ATTR void led_red_on(void) { gpio_high(LED_RED); }
+IRAM_ATTR void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER

--- a/mLRS/Common/hal/esp/rx-hal-generic-2400-td-pa-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-2400-td-pa-esp32.h
@@ -154,7 +154,7 @@ void button_init(void)
     gpio_init(BUTTON, IO_MODE_INPUT_PU);
 }
 
-bool button_pressed(void)
+IRAM_ATTR bool button_pressed(void)
 {
     return gpio_read_activelow(BUTTON) ? true : false;
 }
@@ -175,7 +175,7 @@ void leds_init(void)
     ledRGB.Show();
 }
 
-IRAM_ATTR static inline void led_red_off(void)
+IRAM_ATTR void led_red_off(void)
 {
     if (!ledRedState) return;
     ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
@@ -183,7 +183,7 @@ IRAM_ATTR static inline void led_red_off(void)
     ledRedState = 0;
 }
 
-IRAM_ATTR static inline void led_red_on(void)
+IRAM_ATTR void led_red_on(void)
 {
     if (ledRedState) return;
     ledRGB.SetPixelColor(0, RgbColor(255, 0, 0));
@@ -191,12 +191,12 @@ IRAM_ATTR static inline void led_red_on(void)
     ledRedState = 1;
 }
 
-IRAM_ATTR static inline void led_red_toggle(void)
+IRAM_ATTR void led_red_toggle(void)
 {
     if (ledRedState) { led_red_off(); } else { led_red_on(); }
 }
 
-IRAM_ATTR static inline void led_green_off(void)
+IRAM_ATTR void led_green_off(void)
 {
     if (!ledGreenState) return;
     ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
@@ -204,7 +204,7 @@ IRAM_ATTR static inline void led_green_off(void)
     ledGreenState = 0;
 }
 
-IRAM_ATTR static inline void led_green_on(void)
+IRAM_ATTR void led_green_on(void)
 {
     if (ledGreenState) return;
     ledRGB.SetPixelColor(0, RgbColor(0, 255, 0));
@@ -212,12 +212,12 @@ IRAM_ATTR static inline void led_green_on(void)
     ledGreenState = 1;
 }
 
-IRAM_ATTR static inline void led_green_toggle(void)
+IRAM_ATTR void led_green_toggle(void)
 {
     if (ledGreenState) { led_green_off(); } else { led_green_on(); }
 }
 
-IRAM_ATTR static inline void led_blue_off(void)
+IRAM_ATTR void led_blue_off(void)
 {
     if (!ledBlueState) return;
     ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
@@ -225,7 +225,7 @@ IRAM_ATTR static inline void led_blue_off(void)
     ledBlueState = 0;
 }
 
-IRAM_ATTR static inline void led_blue_on(void)
+IRAM_ATTR void led_blue_on(void)
 {
     if (ledBlueState) return;
     ledRGB.SetPixelColor(0, RgbColor(0, 0, 255));
@@ -233,7 +233,7 @@ IRAM_ATTR static inline void led_blue_on(void)
     ledBlueState = 1;
 }
 
-IRAM_ATTR static inline void led_blue_toggle(void)
+IRAM_ATTR void led_blue_toggle(void)
 {
     if (ledBlueState) { led_blue_off(); } else { led_blue_on(); }
 }

--- a/mLRS/Common/hal/esp/rx-hal-generic-900-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-900-esp8285.h
@@ -81,9 +81,9 @@ void leds_init(void)
     gpio_init(LED_RED, IO_MODE_OUTPUT_PP_LOW);
 }
 
-void led_red_off(void) { gpio_low(LED_RED); }
-void led_red_on(void) { gpio_high(LED_RED); }
-void led_red_toggle(void) { gpio_toggle(LED_RED); }
+IRAM_ATTR void led_red_off(void) { gpio_low(LED_RED); }
+IRAM_ATTR void led_red_on(void) { gpio_high(LED_RED); }
+IRAM_ATTR void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER

--- a/mLRS/Common/hal/esp/rx-hal-generic-900-pa-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-900-pa-esp8285.h
@@ -81,9 +81,9 @@ void leds_init(void)
     gpio_init(LED_RED, IO_MODE_OUTPUT_PP_LOW);
 }
 
-void led_red_off(void) { gpio_low(LED_RED); }
-void led_red_on(void) { gpio_high(LED_RED); }
-void led_red_toggle(void) { gpio_toggle(LED_RED); }
+IRAM_ATTR void led_red_off(void) { gpio_low(LED_RED); }
+IRAM_ATTR void led_red_on(void) { gpio_high(LED_RED); }
+IRAM_ATTR void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER

--- a/mLRS/Common/hal/glue.h
+++ b/mLRS/Common/hal/glue.h
@@ -122,11 +122,6 @@
 #endif
 
 
-void hal_init(void)
-{
-    // nothing to do
-}
-
 
 // setup(), loop() streamlining between Arduino/STM code
 uint8_t restart_controller = 0;

--- a/mLRS/CommonRx/mlrs-rx.cpp
+++ b/mLRS/CommonRx/mlrs-rx.cpp
@@ -130,8 +130,6 @@ tRxSxSerial sx_serial;
 
 void init_hw(void)
 {
-    hal_init();
-    
     delay_init();
     systembootloader_init(); // after delay_init() since it may need delay
     timer_init();

--- a/mLRS/CommonTx/mlrs-tx.cpp
+++ b/mLRS/CommonTx/mlrs-tx.cpp
@@ -203,8 +203,6 @@ void enter_system_bootloader(void)
 
 void init_once(void)
 {
-    hal_init();
-
     serial.InitOnce();
     comport.InitOnce();
     serial2.InitOnce();
@@ -215,8 +213,6 @@ void init_hw(void)
 {
     // disable all interrupts, they may be enabled with restart
     __disable_irq();
-
-    hal_init();
 
     delay_init();
     systembootloader_init(); // after delay_init() since it may need delay

--- a/platformio.ini
+++ b/platformio.ini
@@ -127,6 +127,15 @@ build_flags =
   -D RX_ELRS_GENERIC_2400_TD_PA_ESP32
 
 
+;-- generic ELRS boards with overlays
+
+[env:rx-generic-2400-pa-dcdc]
+extends = env:rx-generic-2400-pa
+build_flags =
+  ${env:rx-generic-2400-pa.build_flags}
+  -D SX_USE_REGULATOR_MODE_DCDC
+
+
 ;-- selected ELRS boards --
 
 [env:rx-bayck-nano-pro-900]


### PR DESCRIPTION
title says it

also added a new target 2400-pa-dcdc, is consequence of me testing the betafpv nano 2.4G receiver ... appears to work equally well without and with DCDC, let's see. Thought better to have it for now.
We could do the same approach of a dcdc target for the betafpv-superd-2400, but can do this later too LOL

tested on betafpv nano 2.4G and nano 900 MHz