### PR TITLE
dev-esp-uart-update

### DIFF
--- a/mLRS/Common/esp-lib/esp-uart-template.h
+++ b/mLRS/Common/esp-lib/esp-uart-template.h
@@ -147,6 +147,7 @@ void uart$_setprotocol(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM sto
 
 void uart$_init(void)
 {
+    UART$_SERIAL_NO.end();
     _uart$_initit(UART$_BAUD, XUART_PARITY_NO, UART_STOPBIT_1);
 }
 

--- a/mLRS/Common/esp-lib/esp-uartb.h
+++ b/mLRS/Common/esp-lib/esp-uartb.h
@@ -147,6 +147,7 @@ void uartb_setprotocol(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM sto
 
 void uartb_init(void)
 {
+    UARTB_SERIAL_NO.end();
     _uartb_initit(UARTB_BAUD, XUART_PARITY_NO, UART_STOPBIT_1);
 }
 

--- a/mLRS/Common/esp-lib/esp-uartc.h
+++ b/mLRS/Common/esp-lib/esp-uartc.h
@@ -147,6 +147,7 @@ void uartc_setprotocol(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM sto
 
 void uartc_init(void)
 {
+    UARTC_SERIAL_NO.end();
     _uartc_initit(UARTC_BAUD, XUART_PARITY_NO, UART_STOPBIT_1);
 }
 

--- a/mLRS/Common/esp-lib/esp-uartf.h
+++ b/mLRS/Common/esp-lib/esp-uartf.h
@@ -147,6 +147,7 @@ void uartf_setprotocol(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM sto
 
 void uartf_init(void)
 {
+    UARTF_SERIAL_NO.end();
     _uartf_initit(UARTF_BAUD, XUART_PARITY_NO, UART_STOPBIT_1);
 }
 


### PR DESCRIPTION
Gets rid of a warning printed to the console after a soft restart.