### PR TITLE
dev-esp-br3-power

### DIFF
--- a/mLRS/Common/hal/esp/rx-hal-radiomaster-br3-900-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-radiomaster-br3-900-esp8285.h
@@ -96,13 +96,13 @@ IRAM_ATTR void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER
-#define POWER_GAIN_DBM            19 // gain of a PA stage if present
+#define POWER_GAIN_DBM            16 // gain of a PA stage if present
 #define POWER_SX1276_MAX_DBM      SX1276_OUTPUT_POWER_MAX // maximum allowed sx power
 #define POWER_USE_DEFAULT_RFPOWER_CALC
 
 #define RFPOWER_DEFAULT           0 // index into rfpower_list array
 
 const rfpower_t rfpower_list[] = {
-    { .dbm = POWER_MIN, .mW = INT8_MIN },  // really about 24 dBm
-    { .dbm = POWER_27_DBM, .mW = 500 },
+    { .dbm = POWER_MIN, .mW = INT8_MIN },  // really about 21 dBm
+    { .dbm = POWER_27_DBM, .mW = 500 },    // 27 dBm
 };

--- a/mLRS/Common/sx-drivers/sx127x_driver.h
+++ b/mLRS/Common/sx-drivers/sx127x_driver.h
@@ -123,7 +123,7 @@ class Sx127xDriverCommon : public Sx127xDriverBase
         // 5 OcpOn, 4-0 OcpTrim
         ReadWriteRegister(SX1276_REG_Ocp, 0x3F, SX1276_OCP_ON | SX1276_OCP_TRIM_150_MA);
 #ifdef SX_USE_RFO
-        SetPowerParams(SX1276_PA_SELECT_RFO, SX1276_MAX_POWER_15_DBM, sx_power, SX1276_PA_RAMP_40_US);
+        SetPowerParams(SX1276_PA_SELECT_RFO, SX1276_MAX_POWER_11p4_DBM, sx_power, SX1276_PA_RAMP_40_US);
 #else
         SetPowerParams(SX1276_PA_SELECT_PA_BOOST, SX1276_MAX_POWER_15_DBM, sx_power, SX1276_PA_RAMP_40_US);
 #endif


### PR DESCRIPTION
- Update SX127x to use 11.4 dBM max power when using RFO
- Update BR3 power levels accordingly