### PR TITLE
dev-esp-rfo, br3 proper

### DIFF
--- a/mLRS/Common/hal/esp/rx-hal-radiomaster-br3-900-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-radiomaster-br3-900-esp8285.h
@@ -96,7 +96,7 @@ IRAM_ATTR void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 
 //-- POWER
-#define POWER_GAIN_DBM            16 // gain of a PA stage if present
+#define POWER_GAIN_DBM            19 // gain of a PA stage if present
 #define POWER_SX1276_MAX_DBM      SX1276_OUTPUT_POWER_MAX // maximum allowed sx power
 #define POWER_USE_DEFAULT_RFPOWER_CALC
 

--- a/mLRS/Common/sx-drivers/sx127x_driver.h
+++ b/mLRS/Common/sx-drivers/sx127x_driver.h
@@ -50,7 +50,7 @@ void sx1276_rfpower_calc(const int8_t power_dbm, uint8_t* sx_power, int8_t* actu
 {
 #ifdef SX_USE_RFO
     // Pout = OutputPower if PaSelect = 0 (RFO pin)
-    int16_t power_sx = (int16_t)power_dbm - GAIN_DBM;
+    int16_t power_sx = (int16_t)power_dbm - GAIN_DBM + 3;
 #else
     // Pout = 17 - (15 - OutputPower) if PaSelect = 1 (PA_BOOST pin)
     int16_t power_sx = (int16_t)power_dbm - GAIN_DBM - 2;
@@ -63,7 +63,7 @@ void sx1276_rfpower_calc(const int8_t power_dbm, uint8_t* sx_power, int8_t* actu
     *sx_power = power_sx;
 
 #ifdef SX_USE_RFO
-    *actual_power_dbm = power_sx + GAIN_DBM;
+    *actual_power_dbm = power_sx + GAIN_DBM - 3;
 #else
     *actual_power_dbm = power_sx + GAIN_DBM + 2;
 #endif


### PR DESCRIPTION
Account for reducing SX power to 11.4 dBm when using RFO output.