### PR TITLE
Improve LQ over rc channel function

### DIFF
--- a/mLRS/Common/common_types.cpp
+++ b/mLRS/Common/common_types.cpp
@@ -80,7 +80,7 @@ uint8_t rssi_i8_to_mavradio(int8_t rssi_i8, bool connected)
 
 
 // -120 ... -50 -> 172 .. 1877
-uint16_t rssi_i8_to_ap_sbus(int8_t rssi_i8)
+uint16_t rssi_i8_to_rc(int8_t rssi_i8)
 {
     if (rssi_i8 == RSSI_INVALID) return 0;
     if (rssi_i8 > -50) return 1877; // max value
@@ -93,12 +93,12 @@ uint16_t rssi_i8_to_ap_sbus(int8_t rssi_i8)
 }
 
 
-// 0 ... 100 -> 191 .. 1792 = 1000 .. 2000 us
-uint16_t lq_to_sbus_crsf(uint8_t lq)
+// 0 ... 100 -> 172 .. 1877 = 1000 .. 2000 us
+uint16_t lq_to_rc(uint8_t lq)
 {
-    if (lq >= 100) return 1792; // max value
+    if (lq >= 100) return 1877; // max value
 
-    return ((uint32_t)lq * 1601 + 50) / 100 + 191;
+    return ((uint32_t)lq * 1705 + 50) / 100 + 172;
 }
 
 

--- a/mLRS/Common/common_types.h
+++ b/mLRS/Common/common_types.h
@@ -121,9 +121,9 @@ uint8_t rssi_u7_from_i8(int8_t rssi_i8);
 int8_t rssi_i8_from_u7(uint8_t rssi_u7);
 uint8_t rssi_i8_to_ap(int8_t rssi_i8);
 uint8_t rssi_i8_to_mavradio(int8_t rssi_i8, bool connected);
-uint16_t rssi_i8_to_ap_sbus(int8_t rssi_i8);
+uint16_t rssi_i8_to_rc(int8_t rssi_i8);
 
-uint16_t lq_to_sbus_crsf(uint8_t lq);
+uint16_t lq_to_rc(uint8_t lq);
 
 
 //-- rc data

--- a/mLRS/CommonRx/out.cpp
+++ b/mLRS/CommonRx/out.cpp
@@ -147,12 +147,12 @@ void OutBase::SendRcData(tRcData* rc_orig, bool frame_missed, bool failsafe, int
 
     if (setup->OutRssiChannelMode >= OUT_RSSI_LQ_CHANNEL_CH5 && setup->OutRssiChannelMode <= OUT_RSSI_LQ_CHANNEL_CH16) {
         uint8_t rssi_channel = setup->OutRssiChannelMode + 4;
-        rc.ch[rssi_channel - 1] = rssi_i8_to_ap_sbus(rssi);
+        rc.ch[rssi_channel - 1] = rssi_i8_to_rc(rssi);
     }
 
     if (setup->OutLqChannelMode >= OUT_RSSI_LQ_CHANNEL_CH5 && setup->OutLqChannelMode <= OUT_RSSI_LQ_CHANNEL_CH16) {
         uint8_t lq_channel = setup->OutLqChannelMode + 4;
-        rc.ch[lq_channel - 1] = lq_to_sbus_crsf(lq);
+        rc.ch[lq_channel - 1] = lq_to_rc(lq);
     }
 
     if (!initialized) return;


### PR DESCRIPTION
Rename the functions which calculate RSSI and LQ for use on an RC channel to be consistent with their purpose and use.  Adjust range of LQ calculation to occupy the full (100%) RC range for more accurate LQ readings without adjusting the range in Ardupilot parameters.

Now, with the default Ardupilot range, the correct full LQ range will now be reported when using RC override.  But the range is still not quite correct when using sbus since Ardupilot and PX4 do not agree with mLRS on the exact range of sbus channel values.  But, at least we get closer with a maximum of 99% reported instead of 94%.  Betaflight and INAV do agree mLRS with respect to sbus channel range.