### PR TITLE
esp, lib, tdiy uart lib

### DIFF
--- a/mLRS/Common/esp-lib/esp-uart-template.h
+++ b/mLRS/Common/esp-lib/esp-uart-template.h
@@ -5,10 +5,17 @@
 //*******************************************************
 // ESP UART$
 //********************************************************
+// For ESP32:
+// usefull resource
+// - https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/uart.html
+//********************************************************
 #ifndef ESPLIB_UART$_H
 #define ESPLIB_UART$_H
 
 
+//-------------------------------------------------------
+// Enums
+//-------------------------------------------------------
 #ifndef ESPLIB_UART_ENUMS
 #define ESPLIB_UART_ENUMS
 
@@ -27,6 +34,10 @@ typedef enum {
 #endif
 
 
+//-------------------------------------------------------
+// Defines
+//-------------------------------------------------------
+
 #ifdef UART$_USE_SERIAL
   #define UART$_SERIAL_NO       Serial
 #elif defined UART$_USE_SERIAL1
@@ -44,12 +55,39 @@ typedef enum {
   #define UART$_RXBUFSIZE       256 // MUST be 2^N
 #endif
 
+#ifdef ESP32
+  #if (UART$_TXBUFSIZE > 0) && (UART$_TXBUFSIZE < 256)
+    #error UART$_TXBUFSIZE must be 0 or >= 256
+  #endif
+  #if (UART$_RXBUFSIZE < 256)
+    #error UART$_RXBUFSIZE must be >= 256
+  #endif
+#endif
+
+
+//-------------------------------------------------------
+// TX routines
+//-------------------------------------------------------
 
 IRAM_ATTR void uart$_putbuf(uint8_t* buf, uint16_t len)
 {
     UART$_SERIAL_NO.write((uint8_t*)buf, len);
 }
 
+
+IRAM_ATTR void uart$_tx_flush(void)
+{
+#ifdef ESP32
+    // flush of tx buffer not available
+#elif defined ESP8266
+    UART$_SERIAL_NO.flush();
+#endif
+}
+
+
+//-------------------------------------------------------
+// RX routines
+//-------------------------------------------------------
 
 IRAM_ATTR char uart$_getc(void)
 {
@@ -63,12 +101,6 @@ IRAM_ATTR void uart$_rx_flush(void)
 }
 
 
-IRAM_ATTR void uart$_tx_flush(void)
-{
-    UART$_SERIAL_NO.flush();
-}
-
-
 IRAM_ATTR uint16_t uart$_rx_bytesavailable(void)
 {
     return (UART$_SERIAL_NO.available() > 0) ? UART$_SERIAL_NO.available() : 0;
@@ -78,11 +110,6 @@ IRAM_ATTR uint16_t uart$_rx_bytesavailable(void)
 IRAM_ATTR uint16_t uart$_rx_available(void)
 {
     return (UART$_SERIAL_NO.available() > 0) ? 1 : 0;
-}
-
-IRAM_ATTR uint8_t uart$_has_systemboot(void)
-{
-    return 0;  // ESP8266, ESP32 can't reboot into system bootloader
 }
 
 
@@ -126,7 +153,7 @@ void _uart$_initit(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM stopbit
     UART$_SERIAL_NO.begin(baud, config);
 #endif
 
-    UART$_SERIAL_NO.setRxFIFOFull(8);  // > 57600 baud sets to 120 which is too much, buffer only 127 bytes
+    UART$_SERIAL_NO.setRxFIFOFull(8);  // > 57600 baud sets to 120 which is too much, buffer only 128 bytes
     UART$_SERIAL_NO.setRxTimeout(1);   // wait for 1 symbol (~11 bits) to trigger Rx ISR, default 2
 
 #elif defined ESP8266
@@ -150,16 +177,28 @@ void uart$_setprotocol(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM sto
 }
 
 
-void uart$_init(void)
+void uart$_init_isroff(void)
 {
     UART$_SERIAL_NO.end();
     _uart$_initit(UART$_BAUD, XUART_PARITY_NO, UART_STOPBIT_1);
 }
 
-void uart$_init_isroff(void)
+
+void uart$_init(void)
 {
-    UART$_SERIAL_NO.end();
-    _uart$_initit(UART$_BAUD, XUART_PARITY_NO, UART_STOPBIT_1);
+    uart$_init_isroff();
+    // isr is enabled !
+}
+
+
+//-------------------------------------------------------
+// System bootloader
+//-------------------------------------------------------
+// ESP8266, ESP32 can't reboot into system bootloader
+
+IRAM_ATTR uint8_t uart$_has_systemboot(void)
+{
+    return 0;
 }
 
 

--- a/mLRS/Common/esp-lib/esp-uartb.h
+++ b/mLRS/Common/esp-lib/esp-uartb.h
@@ -5,10 +5,17 @@
 //*******************************************************
 // ESP UARTB
 //********************************************************
+// For ESP32:
+// usefull resource
+// - https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/uart.html
+//********************************************************
 #ifndef ESPLIB_UARTB_H
 #define ESPLIB_UARTB_H
 
 
+//-------------------------------------------------------
+// Enums
+//-------------------------------------------------------
 #ifndef ESPLIB_UART_ENUMS
 #define ESPLIB_UART_ENUMS
 
@@ -27,6 +34,10 @@ typedef enum {
 #endif
 
 
+//-------------------------------------------------------
+// Defines
+//-------------------------------------------------------
+
 #ifdef UARTB_USE_SERIAL
   #define UARTB_SERIAL_NO       Serial
 #elif defined UARTB_USE_SERIAL1
@@ -44,12 +55,39 @@ typedef enum {
   #define UARTB_RXBUFSIZE       256 // MUST be 2^N
 #endif
 
+#ifdef ESP32
+  #if (UARTB_TXBUFSIZE > 0) && (UARTB_TXBUFSIZE < 256)
+    #error UARTB_TXBUFSIZE must be 0 or >= 256
+  #endif
+  #if (UARTB_RXBUFSIZE < 256)
+    #error UARTB_RXBUFSIZE must be >= 256
+  #endif
+#endif
+
+
+//-------------------------------------------------------
+// TX routines
+//-------------------------------------------------------
 
 IRAM_ATTR void uartb_putbuf(uint8_t* buf, uint16_t len)
 {
     UARTB_SERIAL_NO.write((uint8_t*)buf, len);
 }
 
+
+IRAM_ATTR void uartb_tx_flush(void)
+{
+#ifdef ESP32
+    // flush of tx buffer not available
+#elif defined ESP8266
+    UARTB_SERIAL_NO.flush();
+#endif
+}
+
+
+//-------------------------------------------------------
+// RX routines
+//-------------------------------------------------------
 
 IRAM_ATTR char uartb_getc(void)
 {
@@ -63,12 +101,6 @@ IRAM_ATTR void uartb_rx_flush(void)
 }
 
 
-IRAM_ATTR void uartb_tx_flush(void)
-{
-    UARTB_SERIAL_NO.flush();
-}
-
-
 IRAM_ATTR uint16_t uartb_rx_bytesavailable(void)
 {
     return (UARTB_SERIAL_NO.available() > 0) ? UARTB_SERIAL_NO.available() : 0;
@@ -78,11 +110,6 @@ IRAM_ATTR uint16_t uartb_rx_bytesavailable(void)
 IRAM_ATTR uint16_t uartb_rx_available(void)
 {
     return (UARTB_SERIAL_NO.available() > 0) ? 1 : 0;
-}
-
-IRAM_ATTR uint8_t uartb_has_systemboot(void)
-{
-    return 0;  // ESP can't reboot into system bootloader
 }
 
 
@@ -126,7 +153,7 @@ void _uartb_initit(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM stopbit
     UARTB_SERIAL_NO.begin(baud, config);
 #endif
 
-    UARTB_SERIAL_NO.setRxFIFOFull(8);  // > 57600 baud sets to 120 which is too much, buffer only 127 bytes
+    UARTB_SERIAL_NO.setRxFIFOFull(8);  // > 57600 baud sets to 120 which is too much, buffer only 128 bytes
     UARTB_SERIAL_NO.setRxTimeout(1);   // wait for 1 symbol (~11 bits) to trigger Rx ISR, default 2
 
 #elif defined ESP8266
@@ -150,16 +177,28 @@ void uartb_setprotocol(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM sto
 }
 
 
-void uartb_init(void)
+void uartb_init_isroff(void)
 {
     UARTB_SERIAL_NO.end();
     _uartb_initit(UARTB_BAUD, XUART_PARITY_NO, UART_STOPBIT_1);
 }
 
-void uartb_init_isroff(void)
+
+void uartb_init(void)
 {
-    UARTB_SERIAL_NO.end();
-    _uartb_initit(UARTB_BAUD, XUART_PARITY_NO, UART_STOPBIT_1);
+    uartb_init_isroff();
+    // isr is enabled !
+}
+
+
+//-------------------------------------------------------
+// System bootloader
+//-------------------------------------------------------
+// ESP8266, ESP32 can't reboot into system bootloader
+
+IRAM_ATTR uint8_t uartb_has_systemboot(void)
+{
+    return 0;
 }
 
 

--- a/mLRS/Common/esp-lib/esp-uartc.h
+++ b/mLRS/Common/esp-lib/esp-uartc.h
@@ -5,10 +5,17 @@
 //*******************************************************
 // ESP UARTC
 //********************************************************
+// For ESP32:
+// usefull resource
+// - https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/uart.html
+//********************************************************
 #ifndef ESPLIB_UARTC_H
 #define ESPLIB_UARTC_H
 
 
+//-------------------------------------------------------
+// Enums
+//-------------------------------------------------------
 #ifndef ESPLIB_UART_ENUMS
 #define ESPLIB_UART_ENUMS
 
@@ -27,6 +34,10 @@ typedef enum {
 #endif
 
 
+//-------------------------------------------------------
+// Defines
+//-------------------------------------------------------
+
 #ifdef UARTC_USE_SERIAL
   #define UARTC_SERIAL_NO       Serial
 #elif defined UARTC_USE_SERIAL1
@@ -44,12 +55,39 @@ typedef enum {
   #define UARTC_RXBUFSIZE       256 // MUST be 2^N
 #endif
 
+#ifdef ESP32
+  #if (UARTC_TXBUFSIZE > 0) && (UARTC_TXBUFSIZE < 256)
+    #error UARTC_TXBUFSIZE must be 0 or >= 256
+  #endif
+  #if (UARTC_RXBUFSIZE < 256)
+    #error UARTC_RXBUFSIZE must be >= 256
+  #endif
+#endif
+
+
+//-------------------------------------------------------
+// TX routines
+//-------------------------------------------------------
 
 IRAM_ATTR void uartc_putbuf(uint8_t* buf, uint16_t len)
 {
     UARTC_SERIAL_NO.write((uint8_t*)buf, len);
 }
 
+
+IRAM_ATTR void uartc_tx_flush(void)
+{
+#ifdef ESP32
+    // flush of tx buffer not available
+#elif defined ESP8266
+    UARTC_SERIAL_NO.flush();
+#endif
+}
+
+
+//-------------------------------------------------------
+// RX routines
+//-------------------------------------------------------
 
 IRAM_ATTR char uartc_getc(void)
 {
@@ -63,12 +101,6 @@ IRAM_ATTR void uartc_rx_flush(void)
 }
 
 
-IRAM_ATTR void uartc_tx_flush(void)
-{
-    UARTC_SERIAL_NO.flush();
-}
-
-
 IRAM_ATTR uint16_t uartc_rx_bytesavailable(void)
 {
     return (UARTC_SERIAL_NO.available() > 0) ? UARTC_SERIAL_NO.available() : 0;
@@ -78,11 +110,6 @@ IRAM_ATTR uint16_t uartc_rx_bytesavailable(void)
 IRAM_ATTR uint16_t uartc_rx_available(void)
 {
     return (UARTC_SERIAL_NO.available() > 0) ? 1 : 0;
-}
-
-IRAM_ATTR uint8_t uartc_has_systemboot(void)
-{
-    return 0;  // ESP can't reboot into system bootloader
 }
 
 
@@ -126,7 +153,7 @@ void _uartc_initit(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM stopbit
     UARTC_SERIAL_NO.begin(baud, config);
 #endif
 
-    UARTC_SERIAL_NO.setRxFIFOFull(8);  // > 57600 baud sets to 120 which is too much, buffer only 127 bytes
+    UARTC_SERIAL_NO.setRxFIFOFull(8);  // > 57600 baud sets to 120 which is too much, buffer only 128 bytes
     UARTC_SERIAL_NO.setRxTimeout(1);   // wait for 1 symbol (~11 bits) to trigger Rx ISR, default 2
 
 #elif defined ESP8266
@@ -150,16 +177,28 @@ void uartc_setprotocol(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM sto
 }
 
 
-void uartc_init(void)
+void uartc_init_isroff(void)
 {
     UARTC_SERIAL_NO.end();
     _uartc_initit(UARTC_BAUD, XUART_PARITY_NO, UART_STOPBIT_1);
 }
 
-void uartc_init_isroff(void)
+
+void uartc_init(void)
 {
-    UARTC_SERIAL_NO.end();
-    _uartc_initit(UARTC_BAUD, XUART_PARITY_NO, UART_STOPBIT_1);
+    uartc_init_isroff();
+    // isr is enabled !
+}
+
+
+//-------------------------------------------------------
+// System bootloader
+//-------------------------------------------------------
+// ESP8266, ESP32 can't reboot into system bootloader
+
+IRAM_ATTR uint8_t uartc_has_systemboot(void)
+{
+    return 0;
 }
 
 

--- a/mLRS/Common/hal/esp/rx-hal-radiomaster-rp4td-2400-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-radiomaster-rp4td-2400-esp32.h
@@ -23,7 +23,7 @@
 
 #define UART_USE_SERIAL1 
 #define UART_BAUD                 416666   // CRSF baud rate
-#define UART_USE_TX_IO            18       // t pad on the receiver
+#define UART_USE_TX_IO            IO_P18   // t pad on the receiver
 #define UART_USE_RX_IO            -1       // no Rx pin needed
 #define UART_TXBUFSIZE            256
 

--- a/mLRS/Common/hal/esp/rx-hal-radiomaster-rp4td-2400-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-radiomaster-rp4td-2400-esp32.h
@@ -17,13 +17,15 @@
 
 
 //-- UARTS
+// UARTB = serial port
 // UART = output port, SBus or whatever
+// UARTC = debug port
 
 #define UART_USE_SERIAL1 
 #define UART_BAUD                 416666   // CRSF baud rate
 #define UART_USE_TX_IO            18       // t pad on the receiver
 #define UART_USE_RX_IO            -1       // no Rx pin needed
-#define UART_TXBUFSIZE            128
+#define UART_TXBUFSIZE            256
 
 
 //-- Out port


### PR DESCRIPTION
@tmcadam or @jlpoltrack 

title says it

largely just nfc changes

Two changes relevant to EPS32:
- check of txbuf size, this is what is concluded in the tx module attempt branches
- no tx flush
These were concluded in the tx branches using the esp-idf. Since it's used lowlevel also here I think this shoulöd also apply here,