### PR TITLE
esp, rx, iflight900, swap sx, adjust power

### DIFF
--- a/mLRS/Common/hal/esp/rx-hal-generic-900-td-pa-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-900-td-pa-esp32.h
@@ -31,17 +31,18 @@
 
 
 //-- SX1: SX12xx & SPI
+// antenna1 = left ufl
 
-#define SPI_CS_IO                 IO_P27
+#define SPI_CS_IO                 IO_P13
 #define SPI_MISO                  IO_P33
 #define SPI_MOSI                  IO_P32
 #define SPI_SCK                   IO_P25
 #define SPI_FREQUENCY             10000000L
-#define SX_DIO0                   IO_P36
-#define SX_DIO1                   IO_P37
-#define SX_RESET                  IO_P26
-#define SX_RX_EN                  IO_P10
-#define SX_TX_EN                  IO_P14
+#define SX_DIO0                   IO_P39
+#define SX_DIO1                   IO_P34
+#define SX_RESET                  IO_P21
+#define SX_RX_EN                  IO_P9
+#define SX_TX_EN                  IO_P15
 
 IRQHANDLER(void SX_DIO_EXTI_IRQHandler(void);)
 
@@ -80,13 +81,14 @@ IRAM_ATTR void sx_dio_exti_isr_clearflag(void) {}
 
 
 //-- SX2: SX12xx & SPI
+// antenna1 = right ufl
 
-#define SX2_CS_IO                 IO_P13
-#define SX2_DIO0                  IO_P39
-#define SX2_DIO1                  IO_P34
-#define SX2_RESET                 IO_P21
-#define SX2_RX_EN                 IO_P9
-#define SX2_TX_EN                 IO_P15
+#define SX2_CS_IO                 IO_P27
+#define SX2_DIO0                  IO_P36
+#define SX2_DIO1                  IO_P37
+#define SX2_RESET                 IO_P26
+#define SX2_RX_EN                 IO_P10
+#define SX2_TX_EN                 IO_P14
 
 IRQHANDLER(void SX2_DIO_EXTI_IRQHandler(void);)
 
@@ -231,13 +233,14 @@ IRAM_ATTR void led_blue_toggle(void)
 
 //-- POWER
 
-#define POWER_GAIN_DBM            14 // gain of a PA stage if present
+#define POWER_GAIN_DBM            16 // gain of a PA stage if present
 #define POWER_SX1276_MAX_DBM      SX1276_OUTPUT_POWER_MAX // maximum allowed sx power
 #define POWER_USE_DEFAULT_RFPOWER_CALC
 
 #define RFPOWER_DEFAULT           0 // index into rfpower_list array
 
 const rfpower_t rfpower_list[] = {
-    { .dbm = POWER_MIN, .mW = INT8_MIN },  // really about 19 dBm?
-    { .dbm = POWER_27_DBM, .mW = 500 },    // 27 dBm
+    { .dbm = POWER_20_DBM, .mW = 100 }, // PA=14 gives ~22.5 dBm, 176 mW, PA=16 ~20.5 dBm, 111 mW,
+    { .dbm = POWER_24_DBM, .mW = 250 }, // PA=14 gives ~25 dBm, 330 mW, PA=16 ~24.2 dBm, 256 mW
+    { .dbm = POWER_27_DBM, .mW = 500 }, // PA=14 gives ~26.3 dBm, 420 mW, PA=16 ~25.7 dBm, 370 mW
 };

--- a/mLRS/Common/hal/esp/rx-hal-generic-900-td-pa-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-900-td-pa-esp32.h
@@ -81,7 +81,7 @@ IRAM_ATTR void sx_dio_exti_isr_clearflag(void) {}
 
 
 //-- SX2: SX12xx & SPI
-// antenna1 = right ufl
+// antenna2 = right ufl
 
 #define SX2_CS_IO                 IO_P27
 #define SX2_DIO0                  IO_P36


### PR DESCRIPTION
title says it

- swaps sx and sx2, so that antenna1 is on left ufl, like for the iflight2400 td 250mW
- lowers the power. gives proper values for 100 mW and 250 mW. For 500 mW setting it's lower by 50 mW, but it was low anyway. It appears the PA has reached already nonlinear region, and I don't think one should go too high into it

bench tested on iflight 900 500 mW receiver

I'm not sure we should keep the iflight900 in the docu list. Mine does not appear to work reliable. I cannot change settings without the thing going into continous reset upon next power up. No idea what this is. Also, the transmission appears to be flimsy, when I move or touch it the radio sometimes loses like 1/2 sec worth of packets. Could be the antenna or the connectors, or the hardware itself, don't know, but from the bench behavior I don't put any trust in mine. It also gets surprisingly warm at 100 mW setting ...
