### PR TITLE
common, sx126x fsk bind fix

### DIFF
--- a/mLRS/Common/sx-drivers/sx126x_driver.h
+++ b/mLRS/Common/sx-drivers/sx126x_driver.h
@@ -163,6 +163,9 @@ class Sx126xDriverCommon : public Sx126xDriverBase
 
     void ResetToLoraConfiguration(void)
     {
+        SetStandby(SX126X_STDBY_CONFIG_STDBY_RC);
+        delay_us(1000); // seems ok without, but do it
+        SetPacketType(SX126X_PACKET_TYPE_LORA);
         SetLoraConfigurationByIndex(gconfig->LoraConfigIndex);
     }
 


### PR DESCRIPTION
Binding was broken when using SX126x and starting in FSK mode, this fixes.  Tested on Matek hardware.

Similar commit that was needed for FLRC: https://github.com/olliw42/mLRS/commit/4dce99c798c9846bd8d910e7ecf274dffc8840a6