### PR TITLE
Check python version in run_setup.py + verbose option

### DIFF
--- a/mLRS/CommonRx/mavlink_interface_rx.h
+++ b/mLRS/CommonRx/mavlink_interface_rx.h
@@ -1064,7 +1064,7 @@ void tRxAutoPilot::Do(void)
     uint32_t tnow_ms = millis32(); // we need to get fresh time, since a HEARTBEAT might be received in the main Do loop
 
     if (sysid && ((tnow_ms - heartbeat_tlast_ms) > 2500)) { // we lost connection to our fc
-dbg.puts("\nlost heartbeat");
+//dbg.puts("\nlost heartbeat");
         Init();
         return;
     }
@@ -1085,7 +1085,7 @@ bool tRxAutoPilot::RequestAutopilotVersion(void)
 {
     if (request_autopilot_version) {
         request_autopilot_version = false;
-dbg.puts("\nsend request");
+//dbg.puts("\nsend request");
         return true;
     }
     return false;
@@ -1108,7 +1108,7 @@ void tRxAutoPilot::handle_heartbeat(fmav_message_t* const msg)
     // check if it could be the heartbeat from ArduPilot
     // we also could check if type is proper, but this is very daunting, so don't do
     if (payload.autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA) {
-if (!sysid) { dbg.puts("\ngot heartbeat"); }
+//if (!sysid) { dbg.puts("\ngot heartbeat"); }
         sysid = msg->sysid;
         heartbeat_tlast_ms = millis32();
         autopilot = payload.autopilot;
@@ -1126,14 +1126,14 @@ void tRxAutoPilot::handle_autopilot_version(fmav_message_t* const msg)
     fmav_msg_autopilot_version_decode(&payload, msg);
 
     flight_sw_version = payload.flight_sw_version;
-dbg.puts("\ngot version ");dbg.puts(u32toHEX_s(flight_sw_version));
 
     uint32_t maj = (flight_sw_version & 0xFF000000) >> 24;
     uint32_t min = (flight_sw_version & 0x00FF0000) >> 16;
     uint32_t pat = (flight_sw_version & 0x0000FF00) >> 8;
     version = maj * 10000 + min * 100 + pat;
 
-dbg.puts(" = ");dbg.puts(u32toBCD_s(version));
+//dbg.puts("\ngot version ");dbg.puts(u32toHEX_s(flight_sw_version));
+//dbg.puts(" = ");dbg.puts(u32toBCD_s(version));
 }
 
 #else

--- a/run_setup.py
+++ b/run_setup.py
@@ -14,51 +14,73 @@
 ********************************************************
 '''
 import os
-import shutil
+import subprocess 
 import re
 import sys
 
+verbose = False
+if '--verbose' in sys.argv:
+    verbose = True
 
 mLRSProjectdirectory = os.path.dirname(os.path.abspath(__file__))
 mLRSdirectory = os.path.join(mLRSProjectdirectory,'mLRS')
 
 
 def os_system(arg):
-    res = os.system(arg)
+    stdout = None if verbose else subprocess.DEVNULL
+    res = subprocess.call(arg, stdout=stdout)
     if res != 0:
         print('# ERROR (errno =',res,') DONE #')
         os.system("pause")
         exit(1)
 
+
+def check_python(cmd):
+    try: 
+        ans = subprocess.check_output([cmd, "--version"], text=True )
+        major_version = re.findall(r'\d', ans)[0]
+        return int(major_version)
+    except Exception as e:
+        return 0
+
+
 def git_submodules_update():
     print('----------------------------------------')
     print(' run git submodule update --init --recursive')
     print('----------------------------------------')
-    os_system('git submodule update --init --recursive')
+    os_system(['git', 'submodule', 'update', '--init', '--recursive'])
     print('# DONE #')
 
 
-def copy_st_drivers():
+def copy_st_drivers(python_cmd):
     print('----------------------------------------')
     print(' run run_copy_st_drivers.py')
     print('----------------------------------------')
     os.chdir(os.path.join(mLRSProjectdirectory,'tools'))
-    os_system(os.path.join('.','run_copy_st_drivers.py -silent'))
+    os_system([python_cmd, os.path.join('.' , 'run_copy_st_drivers.py'), '-silent'])    
     print('# DONE #')
 
 
-def generate_mavlink_c_library():
+def generate_mavlink_c_library(python_cmd):
     print('----------------------------------------')
     print(' run fmav_generate_c_library.py')
     print('----------------------------------------')
     os.chdir(os.path.join(mLRSdirectory,'Common','mavlink'))
-    os_system(os.path.join('.','fmav_generate_c_library.py'))
+    os_system([python_cmd, os.path.join('.','fmav_generate_c_library.py')])
     print('# DONE #')
 
 
+# Find which Python cmd to use
+if check_python("python") == 3:
+    python_cmd = "python"
+elif check_python("python3") == 3:
+    python_cmd = "python3"
+else:
+    raise Exception("Please make sure Python 3 is available on your system")
+
+
 git_submodules_update()
-copy_st_drivers()
-generate_mavlink_c_library()
+copy_st_drivers(python_cmd)
+generate_mavlink_c_library(python_cmd)
 
 os.system("pause")
-


### PR DESCRIPTION
This PR updates `run_setup.py` to make it run more consistently regardless of platform or system setup:

- checks for python or python3
- changes run_setup.py sub-commands to use python (or python3) explicitly
- updates the script to use subprocess module instead of os.system
- adds a --verbose option to run with or without output