### PR TITLE
matek, mr900-22 dc-dc

### DIFF
--- a/mLRS/Common/hal/matek/rx-hal-matek-mr900-22-wle5cc.h
+++ b/mLRS/Common/hal/matek/rx-hal-matek-mr900-22-wle5cc.h
@@ -30,6 +30,7 @@ SWC     solder pad      PA14        SWDCLK      ADC_IN10
 
 #define DEVICE_HAS_OUT
 #define DEVICE_HAS_DEBUG_SWUART
+#define SX_USE_REGULATOR_MODE_DCDC
 
 
 //-- Timers, Timing, EEPROM, and such stuff


### PR DESCRIPTION
Enables the DC-DC converter for the Matek mR900-22.  Tested and works fine - should save about 10mA based on previous tests with Wio E5 Mini.