### PR TITLE
Wioe5 rx system boot

### DIFF
--- a/mLRS/Common/hal/stm32/rx-hal-WioE5-Mini-wle5jc.h
+++ b/mLRS/Common/hal/stm32/rx-hal-WioE5-Mini-wle5jc.h
@@ -14,6 +14,7 @@
 
 #define DEVICE_HAS_OUT
 #define DEVICE_HAS_SINGLE_LED
+#define DEVICE_HAS_SYSTEMBOOT
 
 
 //-- Timers, Timing, EEPROM, and such stuff
@@ -187,6 +188,26 @@ void led_green_toggle(void) { gpio_toggle(LED_GREEN); }
 void led_red_off(void) { gpio_high(LED_RED); }
 void led_red_on(void) { gpio_low(LED_RED); }
 void led_red_toggle(void) { gpio_toggle(LED_RED); }
+
+
+//-- SystemBootLoader
+
+#define BOOT_BUTTON               IO_PB13
+
+extern "C" { void delay_ms(uint16_t ms); }
+
+void systembootloader_init(void)
+{
+    gpio_init(BOOT_BUTTON, IO_MODE_INPUT_PU, IO_SPEED_DEFAULT);
+    delay_ms(10);
+    uint8_t cnt = 0;
+    for (uint8_t i = 0; i < 16; i++) {
+        if (gpio_read_activelow(BOOT_BUTTON)) cnt++;
+    }
+    if (cnt > 12) {
+        BootLoaderInit();
+    }
+}
 
 
 //-- POWER

--- a/mLRS/Common/hal/stm32/rx-hal-WioE5-Mini-wle5jc.h
+++ b/mLRS/Common/hal/stm32/rx-hal-WioE5-Mini-wle5jc.h
@@ -194,8 +194,6 @@ void led_red_toggle(void) { gpio_toggle(LED_RED); }
 
 #define BOOT_BUTTON               IO_PB13
 
-extern "C" { void delay_ms(uint16_t ms); }
-
 void systembootloader_init(void)
 {
     gpio_init(BOOT_BUTTON, IO_MODE_INPUT_PU, IO_SPEED_DEFAULT);

--- a/mLRS/Common/hal/stm32/rx-hal-WioE5-Mini-wle5jc.h
+++ b/mLRS/Common/hal/stm32/rx-hal-WioE5-Mini-wle5jc.h
@@ -199,7 +199,6 @@ extern "C" { void delay_ms(uint16_t ms); }
 void systembootloader_init(void)
 {
     gpio_init(BOOT_BUTTON, IO_MODE_INPUT_PU, IO_SPEED_DEFAULT);
-    delay_ms(10);
     uint8_t cnt = 0;
     for (uint8_t i = 0; i < 16; i++) {
         if (gpio_read_activelow(BOOT_BUTTON)) cnt++;


### PR DESCRIPTION
Enables one to enter the system bootloader on E5 Mini receiver using the button, mostly for convenience.  

Process: - hold down button, then hit reset button.