### PR TITLE
mR900 Power Tweaks

### DIFF
--- a/mLRS/Common/hal/hal-power-pa.h
+++ b/mLRS/Common/hal/hal-power-pa.h
@@ -109,7 +109,6 @@ const rfpower_t rfpower_list[] = {
 
 const rfpower_t rfpower_list[] = {
     { .dbm = POWER_0_DBM, .mW = 1 },
-    { .dbm = POWER_3_DBM, .mW = 2 },
     { .dbm = POWER_10_DBM, .mW = 10 },
     { .dbm = POWER_17_DBM, .mW = 50 },
 };
@@ -142,6 +141,7 @@ const rfpower_t rfpower_list[] = {
 // PA max 30 dBm, PAin max 10 dBm, PA gain 26 dB, LNA gain 16 dB
 #if defined POWER_PA_SE2435L || defined POWER_PA_MATEK_MR900_30 // Matek mR900-30
 #define POWER_PA_DEFINED
+#define POWER_USE_PA_CONFIG_10_DBM
 
 // SX126X power setting can vary from -9 .. 22 for -9 dBm ... 22 dBm
 #include "../setup_types.h"

--- a/mLRS/Common/hal/hal-power-pa.h
+++ b/mLRS/Common/hal/hal-power-pa.h
@@ -109,6 +109,7 @@ const rfpower_t rfpower_list[] = {
 
 const rfpower_t rfpower_list[] = {
     { .dbm = POWER_0_DBM, .mW = 1 },
+    { .dbm = POWER_3_DBM, .mW = 2 },
     { .dbm = POWER_10_DBM, .mW = 10 },
     { .dbm = POWER_17_DBM, .mW = 50 },
 };
@@ -152,27 +153,31 @@ void sx126x_rfpower_calc(const int8_t power_dbm, uint8_t* sx_power, int8_t* actu
         *actual_power_dbm = 30;
     } else
     if (power_dbm >= POWER_27_DBM) {
-        *sx_power = (frequency_band == SX_FHSS_CONFIG_FREQUENCY_BAND_868_MHZ) ? -6 : -3;
+        *sx_power = (frequency_band == SX_FHSS_CONFIG_FREQUENCY_BAND_868_MHZ) ? 2 : 4;
         *actual_power_dbm = 27;
     } else
     if (power_dbm >= POWER_24_DBM) {
-        *sx_power = (frequency_band == SX_FHSS_CONFIG_FREQUENCY_BAND_868_MHZ) ? -9 : -6;
+        *sx_power = (frequency_band == SX_FHSS_CONFIG_FREQUENCY_BAND_868_MHZ) ? -2 : 0;
         *actual_power_dbm = 24;
     } else
-    if (power_dbm >= POWER_22_DBM) {
-        *sx_power = (frequency_band == SX_FHSS_CONFIG_FREQUENCY_BAND_868_MHZ) ? -9 : -8;
-        *actual_power_dbm = (frequency_band == SX_FHSS_CONFIG_FREQUENCY_BAND_868_MHZ) ? 24 : 22;
-    } else {
+    if (power_dbm >= POWER_20_DBM) {
+        *sx_power = (frequency_band == SX_FHSS_CONFIG_FREQUENCY_BAND_868_MHZ) ? -6 : -4;
+        *actual_power_dbm = 20;
+    } else
+	if (power_dbm >= POWER_17_DBM) {
+		*sx_power = (frequency_band == SX_FHSS_CONFIG_FREQUENCY_BAND_868_MHZ) ? -8 : -7;
+		*actual_power_dbm = 17;
+	} else {
         *sx_power = -9;
-        *actual_power_dbm = (frequency_band == SX_FHSS_CONFIG_FREQUENCY_BAND_868_MHZ) ? 24 : 21;
+        *actual_power_dbm = (frequency_band == SX_FHSS_CONFIG_FREQUENCY_BAND_868_MHZ) ? 16 : 14;
     }
 }
 
 #define RFPOWER_DEFAULT           1 // index into rfpower_list array
 
 const rfpower_t rfpower_list[] = {
-    { .dbm = POWER_MIN, .mW = INT8_MIN },
-    { .dbm = POWER_22_DBM, .mW = 150 },
+    { .dbm = POWER_17_DBM, .mW = 50 },
+    { .dbm = POWER_20_DBM, .mW = 100 },
     { .dbm = POWER_24_DBM, .mW = 250 },
     { .dbm = POWER_27_DBM, .mW = 500 },
     { .dbm = POWER_30_DBM, .mW = 1000 },

--- a/mLRS/Common/sx-drivers/sx126x_driver.h
+++ b/mLRS/Common/sx-drivers/sx126x_driver.h
@@ -250,11 +250,11 @@ class Sx126xDriverCommon : public Sx126xDriverBase
         SetRxGain(SX126X_RX_GAIN_BOOSTED_GAIN);
         SetOverCurrentProtection(SX126X_OCP_CONFIGURATION_140_MA); // default for SX1262 according to data sheet, but can't hurt
 
-        #if defined POWER_USE_PA_CONFIG_10_DBM 
+#ifdef POWER_USE_PA_CONFIG_10_DBM 
         SetPaConfig_10dbm();
-        #else
+#else
         SetPaConfig_22dbm();
-        #endif
+#endif
 
         SetRfPower_dbm(gconfig->Power_dbm);
 

--- a/mLRS/Common/sx-drivers/sx126x_driver.h
+++ b/mLRS/Common/sx-drivers/sx126x_driver.h
@@ -250,7 +250,7 @@ class Sx126xDriverCommon : public Sx126xDriverBase
         SetRxGain(SX126X_RX_GAIN_BOOSTED_GAIN);
         SetOverCurrentProtection(SX126X_OCP_CONFIGURATION_140_MA); // default for SX1262 according to data sheet, but can't hurt
 
-        #if defined POWER_PA_SE2435L || defined POWER_PA_MATEK_MR900_30 
+        #if defined POWER_USE_PA_CONFIG_10_DBM 
         SetPaConfig_10dbm();
         #else
         SetPaConfig_22dbm();

--- a/mLRS/Common/sx-drivers/sx126x_driver.h
+++ b/mLRS/Common/sx-drivers/sx126x_driver.h
@@ -150,7 +150,7 @@ class Sx126xDriverCommon : public Sx126xDriverBase
 
         // set LoRaSymbNumTimeout for false detection of preamble
         // must come in this order, datasheet 14.5 Issuing Commands in the Right Order, p.103
-//fails with corrected reg byte! SetSymbNumTimeout((config->PreambleLength * 3) >> 2);
+        //fails with corrected reg byte! SetSymbNumTimeout((config->PreambleLength * 3) >> 2);
     }
 
     void SetLoraConfigurationByIndex(uint8_t index)
@@ -250,7 +250,11 @@ class Sx126xDriverCommon : public Sx126xDriverBase
         SetRxGain(SX126X_RX_GAIN_BOOSTED_GAIN);
         SetOverCurrentProtection(SX126X_OCP_CONFIGURATION_140_MA); // default for SX1262 according to data sheet, but can't hurt
 
+        #if defined POWER_PA_SE2435L || defined POWER_PA_MATEK_MR900_30 
+        SetPaConfig_10dbm();
+        #else
         SetPaConfig_22dbm();
+        #endif
 
         SetRfPower_dbm(gconfig->Power_dbm);
 


### PR DESCRIPTION
- Enables 50 mW, 100 mW power levels on mR900-30 gear
- Adds 3 dBm power level to bare SX127x to allow for symmetric power output with minimum R9M power level
- Comment tidy