### PR TITLE
DIY F1 E28 DC-DC Updates

### DIFF
--- a/mLRS/Common/hal/stm32/rx-hal-diy-e28dual-board02-f103cb.h
+++ b/mLRS/Common/hal/stm32/rx-hal-diy-e28dual-board02-f103cb.h
@@ -75,7 +75,7 @@
 #define SPI_USE_SPI1 // PA5, PA6, PA7
 #define SPI_CS_IO                 IO_PB0
 #define SPI_USE_CLK_LOW_1EDGE     // datasheet says CPHA = 0  CPOL = 0
-#define SPI_USE_CLOCKSPEED_18MHZ
+#define SPI_USE_CLOCKSPEED_9MHZ
 
 #define SX_RESET                  IO_PB5
 #define SX_DIO1                   IO_PB3
@@ -149,7 +149,7 @@ void sx_dio_exti_isr_clearflag(void)
 #define SPIB_USE_SPI2             // PB13, PB14, PB15
 #define SPIB_CS_IO                IO_PA8
 #define SPIB_USE_CLK_LOW_1EDGE    // datasheet says CPHA = 0  CPOL = 0
-#define SPIB_USE_CLOCKSPEED_18MHZ
+#define SPIB_USE_CLOCKSPEED_9MHZ
 
 #define SX2_RESET                 IO_PA4
 #define SX2_DIO1                  IO_PA1

--- a/mLRS/Common/hal/stm32/rx-hal-diy-e28dual-board02-f103cb.h
+++ b/mLRS/Common/hal/stm32/rx-hal-diy-e28dual-board02-f103cb.h
@@ -76,7 +76,6 @@
 #define SPI_CS_IO                 IO_PB0
 #define SPI_USE_CLK_LOW_1EDGE     // datasheet says CPHA = 0  CPOL = 0
 #define SPI_USE_CLOCKSPEED_18MHZ
-#define SX_USE_REGULATOR_MODE_DCDC
 
 #define SX_RESET                  IO_PB5
 #define SX_DIO1                   IO_PB3
@@ -90,6 +89,8 @@
 #define SX_DIO_EXTI_IRQn              EXTI3_IRQn
 #define SX_DIO_EXTI_IRQHandler        EXTI3_IRQHandler
 //#define SX_DIO_EXTI_IRQ_PRIORITY    11
+
+#define SX_USE_REGULATOR_MODE_DCDC
 
 void sx_init_gpio(void)
 {
@@ -149,7 +150,6 @@ void sx_dio_exti_isr_clearflag(void)
 #define SPIB_CS_IO                IO_PA8
 #define SPIB_USE_CLK_LOW_1EDGE    // datasheet says CPHA = 0  CPOL = 0
 #define SPIB_USE_CLOCKSPEED_18MHZ
-#define SX2_USE_REGULATOR_MODE_DCDC
 
 #define SX2_RESET                 IO_PA4
 #define SX2_DIO1                  IO_PA1
@@ -163,6 +163,8 @@ void sx_dio_exti_isr_clearflag(void)
 #define SX2_DIO_EXTI_IRQn             EXTI1_IRQn
 #define SX2_DIO_EXTI_IRQHandler       EXTI1_IRQHandler
 //#define SX2_DIO_EXTI_IRQ_PRIORITY   11
+
+#define SX2_USE_REGULATOR_MODE_DCDC
 
 void sx2_init_gpio(void)
 {

--- a/mLRS/Common/hal/stm32/rx-hal-diy-e28dual-board02-f103cb.h
+++ b/mLRS/Common/hal/stm32/rx-hal-diy-e28dual-board02-f103cb.h
@@ -75,7 +75,8 @@
 #define SPI_USE_SPI1 // PA5, PA6, PA7
 #define SPI_CS_IO                 IO_PB0
 #define SPI_USE_CLK_LOW_1EDGE     // datasheet says CPHA = 0  CPOL = 0
-#define SPI_USE_CLOCKSPEED_9MHZ
+#define SPI_USE_CLOCKSPEED_18MHZ
+#define SX_USE_REGULATOR_MODE_DCDC
 
 #define SX_RESET                  IO_PB5
 #define SX_DIO1                   IO_PB3
@@ -147,7 +148,8 @@ void sx_dio_exti_isr_clearflag(void)
 #define SPIB_USE_SPI2             // PB13, PB14, PB15
 #define SPIB_CS_IO                IO_PA8
 #define SPIB_USE_CLK_LOW_1EDGE    // datasheet says CPHA = 0  CPOL = 0
-#define SPIB_USE_CLOCKSPEED_9MHZ
+#define SPIB_USE_CLOCKSPEED_18MHZ
+#define SX2_USE_REGULATOR_MODE_DCDC
 
 #define SX2_RESET                 IO_PA4
 #define SX2_DIO1                  IO_PA1

--- a/mLRS/Common/hal/stm32/tx-hal-diy-e28dual-board02-f103cb.h
+++ b/mLRS/Common/hal/stm32/tx-hal-diy-e28dual-board02-f103cb.h
@@ -108,7 +108,7 @@
 #define SPI_USE_SPI1 // PA5, PA6, PA7
 #define SPI_CS_IO                 IO_PB0
 #define SPI_USE_CLK_LOW_1EDGE     // datasheet says CPHA = 0  CPOL = 0
-#define SPI_USE_CLOCKSPEED_18MHZ
+#define SPI_USE_CLOCKSPEED_9MHZ
 
 #define SX_RESET                  IO_PB5
 #define SX_DIO1                   IO_PB3
@@ -182,7 +182,7 @@ void sx_dio_exti_isr_clearflag(void)
 #define SPIB_USE_SPI2             // PB13, PB14, PB15
 #define SPIB_CS_IO                IO_PA8
 #define SPIB_USE_CLK_LOW_1EDGE    // datasheet says CPHA = 0  CPOL = 0
-#define SPIB_USE_CLOCKSPEED_18MHZ
+#define SPIB_USE_CLOCKSPEED_9MHZ
 
 #define SX2_RESET                 IO_PA4
 #define SX2_DIO1                  IO_PA1

--- a/mLRS/Common/hal/stm32/tx-hal-diy-e28dual-board02-f103cb.h
+++ b/mLRS/Common/hal/stm32/tx-hal-diy-e28dual-board02-f103cb.h
@@ -109,7 +109,6 @@
 #define SPI_CS_IO                 IO_PB0
 #define SPI_USE_CLK_LOW_1EDGE     // datasheet says CPHA = 0  CPOL = 0
 #define SPI_USE_CLOCKSPEED_18MHZ
-#define SX_USE_REGULATOR_MODE_DCDC
 
 #define SX_RESET                  IO_PB5
 #define SX_DIO1                   IO_PB3
@@ -123,6 +122,8 @@
 #define SX_DIO_EXTI_IRQn              EXTI3_IRQn
 #define SX_DIO_EXTI_IRQHandler        EXTI3_IRQHandler
 //#define SX_DIO_EXTI_IRQ_PRIORITY    11
+
+#define SX_USE_REGULATOR_MODE_DCDC
 
 void sx_init_gpio(void)
 {
@@ -182,7 +183,6 @@ void sx_dio_exti_isr_clearflag(void)
 #define SPIB_CS_IO                IO_PA8
 #define SPIB_USE_CLK_LOW_1EDGE    // datasheet says CPHA = 0  CPOL = 0
 #define SPIB_USE_CLOCKSPEED_18MHZ
-#define SX2_USE_REGULATOR_MODE_DCDC
 
 #define SX2_RESET                 IO_PA4
 #define SX2_DIO1                  IO_PA1
@@ -196,6 +196,8 @@ void sx_dio_exti_isr_clearflag(void)
 #define SX2_DIO_EXTI_IRQn             EXTI1_IRQn
 #define SX2_DIO_EXTI_IRQHandler       EXTI1_IRQHandler
 //#define SX2_DIO_EXTI_IRQ_PRIORITY   11
+
+#define SX2_USE_REGULATOR_MODE_DCDC
 
 void sx2_init_gpio(void)
 {

--- a/mLRS/Common/hal/stm32/tx-hal-diy-e28dual-board02-f103cb.h
+++ b/mLRS/Common/hal/stm32/tx-hal-diy-e28dual-board02-f103cb.h
@@ -108,7 +108,8 @@
 #define SPI_USE_SPI1 // PA5, PA6, PA7
 #define SPI_CS_IO                 IO_PB0
 #define SPI_USE_CLK_LOW_1EDGE     // datasheet says CPHA = 0  CPOL = 0
-#define SPI_USE_CLOCKSPEED_9MHZ
+#define SPI_USE_CLOCKSPEED_18MHZ
+#define SX_USE_REGULATOR_MODE_DCDC
 
 #define SX_RESET                  IO_PB5
 #define SX_DIO1                   IO_PB3
@@ -180,7 +181,8 @@ void sx_dio_exti_isr_clearflag(void)
 #define SPIB_USE_SPI2             // PB13, PB14, PB15
 #define SPIB_CS_IO                IO_PA8
 #define SPIB_USE_CLK_LOW_1EDGE    // datasheet says CPHA = 0  CPOL = 0
-#define SPIB_USE_CLOCKSPEED_9MHZ
+#define SPIB_USE_CLOCKSPEED_18MHZ
+#define SX2_USE_REGULATOR_MODE_DCDC
 
 #define SX2_RESET                 IO_PA4
 #define SX2_DIO1                  IO_PA1


### PR DESCRIPTION
Updates for the F1 E28 Dual board:

- Increase SPI speed to 18 MHz, helps with jitter
- Enable DC-DC converter on E28, saves about 20 mA (2 x 10 mA)

Have been running this configuration myself for long time.