### PR TITLE
Fix race when tasks take longer than doSysTask tick

### DIFF
--- a/mLRS/Common/hal/esp-timer.h
+++ b/mLRS/Common/hal/esp-timer.h
@@ -17,7 +17,10 @@
 #define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
 
 
-volatile uint32_t doSysTask = 0;
+// Two variables are required to avoid race with HAL_IncTick() when tasks may take longer than one tick
+volatile uint32_t doSysTask = 0; // Only changed in ISR; incremented to signal tick
+uint32_t doneSysTask = 0; // Never changed in ISR; incremented when (doSysTask != doneSysTask)
+
 volatile uint32_t uwTick = 0;
 
 
@@ -109,6 +112,7 @@ uint16_t micros16(void)
 void timer_init(void)
 {
     doSysTask = 0;
+    doneSysTask = 0;
     uwTick = 0;
     systick_millis_init();
     micros_init();

--- a/mLRS/Common/hal/esp-timer.h
+++ b/mLRS/Common/hal/esp-timer.h
@@ -28,11 +28,10 @@ void resetSysTask()
 
 volatile bool doSysTask()
 {
-    if (uwTick != doSysTask_done)
-        {
-            doSysTask_done++;
-            return true;
-        }
+    if (uwTick != doSysTask_done) {
+        doSysTask_done++;
+        return true;
+    }
     return false;
 }
 

--- a/mLRS/Common/hal/timer.h
+++ b/mLRS/Common/hal/timer.h
@@ -27,11 +27,10 @@ void resetSysTask()
 
 volatile bool doSysTask()
 {
-    if (uwTick != doSysTask_done)
-        {
-            doSysTask_done++;
-            return true;
-        }
+    if (uwTick != doSysTask_done) {
+        doSysTask_done++;
+        return true;
+    }
     return false;
 }
 

--- a/mLRS/Common/hal/timer.h
+++ b/mLRS/Common/hal/timer.h
@@ -17,8 +17,9 @@
 
 #define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
 
-
-volatile uint32_t doSysTask = 0;
+// Two variables are required to avoid race with HAL_IncTick() when tasks may take longer than one tick
+volatile uint32_t doSysTask = 0; // Only changed in ISR; incremented to signal tick
+uint32_t doneSysTask = 0; // Never changed in ISR; incremented when (doSysTask != doneSysTask)
 
 
 void HAL_IncTick(void) // overwrites __weak declaration in stm32yyxx_hal.c
@@ -79,6 +80,7 @@ static uint16_t last_cnt;
 void timer_init(void)
 {
     doSysTask = 0;
+    doneSysTask = 0;
     micros_init();
 }
 

--- a/mLRS/Common/hal/timer.h
+++ b/mLRS/Common/hal/timer.h
@@ -18,14 +18,26 @@
 #define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
 
 // Two variables are required to avoid race with HAL_IncTick() when tasks may take longer than one tick
-volatile uint32_t doSysTask = 0; // Only changed in ISR; incremented to signal tick
-uint32_t doneSysTask = 0; // Never changed in ISR; incremented when (doSysTask != doneSysTask)
+uint32_t doSysTask_done = 0; // Never changed in ISR; incremented when (uwTick != doSysTask_done)
 
+void resetSysTask()
+{
+    doSysTask_done = uwTick;
+}
+
+volatile bool doSysTask()
+{
+    if (uwTick != doSysTask_done)
+        {
+            doSysTask_done++;
+            return true;
+        }
+    return false;
+}
 
 void HAL_IncTick(void) // overwrites __weak declaration in stm32yyxx_hal.c
 {
     uwTick += uwTickFreq;
-    doSysTask++;
 }
 
 
@@ -79,9 +91,8 @@ static uint16_t last_cnt;
 
 void timer_init(void)
 {
-    doSysTask = 0;
-    doneSysTask = 0;
     micros_init();
+    resetSysTask();
 }
 
 

--- a/mLRS/CommonRx/mlrs-rx.cpp
+++ b/mLRS/CommonRx/mlrs-rx.cpp
@@ -581,13 +581,13 @@ RESTARTCONTROLLER
 
     tick_1hz = 0;
     tick_1hz_commensurate = 0;
-    doSysTask = 0; // helps in avoiding too short first loop
+    doneSysTask = doSysTask; // helps in avoiding too short first loop
 INITCONTROLLER_END
 
     //-- SysTask handling
 
-    if (doSysTask) {
-        doSysTask = 0;
+    if (doSysTask != doneSysTask) {
+        doneSysTask++;
 
         if (connect_tmo_cnt) {
             connect_tmo_cnt--;

--- a/mLRS/CommonRx/mlrs-rx.cpp
+++ b/mLRS/CommonRx/mlrs-rx.cpp
@@ -581,13 +581,12 @@ RESTARTCONTROLLER
 
     tick_1hz = 0;
     tick_1hz_commensurate = 0;
-    doneSysTask = doSysTask; // helps in avoiding too short first loop
+    resetSysTask(); // helps in avoiding too short first loop
 INITCONTROLLER_END
 
     //-- SysTask handling
 
-    if (doSysTask != doneSysTask) {
-        doneSysTask++;
+    if (doSysTask()) {
 
         if (connect_tmo_cnt) {
             connect_tmo_cnt--;

--- a/mLRS/CommonTx/esp.h
+++ b/mLRS/CommonTx/esp.h
@@ -235,8 +235,7 @@ void tTxEspWifiBridge::passthrough_do_rts_cts(void)
 
     while (1) {
 
-        if (doSysTask != doneSysTask) {
-            doneSysTask++;
+        if (doSysTask()) {
             leds.TickPassthrough_ms();
         }
 
@@ -329,8 +328,7 @@ void tTxEspWifiBridge::passthrough_do(void)
     com->flush();
 
     while (1) {
-        if (doSysTask != doneSysTask) {
-            doneSysTask++;
+        if (doSysTask()) {
             leds.TickPassthrough_ms();
         }
 

--- a/mLRS/CommonTx/esp.h
+++ b/mLRS/CommonTx/esp.h
@@ -235,8 +235,8 @@ void tTxEspWifiBridge::passthrough_do_rts_cts(void)
 
     while (1) {
 
-        if (doSysTask) {
-            doSysTask = 0;
+        if (doSysTask != doneSysTask) {
+            doneSysTask++;
             leds.TickPassthrough_ms();
         }
 
@@ -329,8 +329,8 @@ void tTxEspWifiBridge::passthrough_do(void)
     com->flush();
 
     while (1) {
-        if (doSysTask) {
-            doSysTask = 0;
+        if (doSysTask != doneSysTask) {
+            doneSysTask++;
             leds.TickPassthrough_ms();
         }
 

--- a/mLRS/CommonTx/hc04.h
+++ b/mLRS/CommonTx/hc04.h
@@ -123,8 +123,8 @@ void tTxHc04Bridge::passthrough_do(void)
     disp.DrawNotify("HC04\nPASSTHRU");
 
     while (1) {
-        if (doSysTask) {
-            doSysTask = 0;
+        if (doSysTask != doneSysTask) {
+            doneSysTask++;
             leds.TickPassthrough_ms();
         }
 

--- a/mLRS/CommonTx/hc04.h
+++ b/mLRS/CommonTx/hc04.h
@@ -123,8 +123,7 @@ void tTxHc04Bridge::passthrough_do(void)
     disp.DrawNotify("HC04\nPASSTHRU");
 
     while (1) {
-        if (doSysTask != doneSysTask) {
-            doneSysTask++;
+        if (doSysTask()) {
             leds.TickPassthrough_ms();
         }
 

--- a/mLRS/CommonTx/mlrs-tx.cpp
+++ b/mLRS/CommonTx/mlrs-tx.cpp
@@ -748,15 +748,15 @@ RESTARTCONTROLLER
 
     tick_1hz = 0;
     tick_1hz_commensurate = 0;
-    doSysTask = 0; // helps in avoiding too short first loop
+    doneSysTask = doSysTask; // helps in avoiding too short first loop
 INITCONTROLLER_END
 
     //-- SysTask handling
 
-    if (doSysTask) {
+    if (doSysTask != doneSysTask) {
         // when we do long tasks, like display transfer, we miss ticks, so we need to catch up
         // the commands below must not be sensitive to strict ms timing
-        doSysTask--; // doSysTask = 0;
+        doneSysTask++;
 
         if (connect_tmo_cnt) {
             connect_tmo_cnt--;

--- a/mLRS/CommonTx/mlrs-tx.cpp
+++ b/mLRS/CommonTx/mlrs-tx.cpp
@@ -748,15 +748,14 @@ RESTARTCONTROLLER
 
     tick_1hz = 0;
     tick_1hz_commensurate = 0;
-    doneSysTask = doSysTask; // helps in avoiding too short first loop
+    resetSysTask(); // helps in avoiding too short first loop
 INITCONTROLLER_END
 
     //-- SysTask handling
 
-    if (doSysTask != doneSysTask) {
+    if (doSysTask()) {
         // when we do long tasks, like display transfer, we miss ticks, so we need to catch up
         // the commands below must not be sensitive to strict ms timing
-        doneSysTask++;
 
         if (connect_tmo_cnt) {
             connect_tmo_cnt--;


### PR DESCRIPTION
Since the "--" operator is not generally atomic in RISC architectures and, I believe, specifically not on STM32 or ESP32 where the decrement is implemented as load, modify, store, the change from clearing doSysTask to decrementing it introduced a race.

I am not aware that this race has ever caused an observed problem as it should be fairly rare, but, consider what would happen.
In the case where the ISR executes between the load and store; the increment in HAL_IncTick() is effectively lost which can make the Tx transmit 1 ms late which could cause the problem on the Rx which we are now all too familiar with.

I believe the method implemented here is the most efficient way to avoid this race.