### PR TITLE
Mr24 power tweaks

### DIFF
--- a/mLRS/Common/hal/hal-power-pa.h
+++ b/mLRS/Common/hal/hal-power-pa.h
@@ -67,14 +67,40 @@ const rfpower_t rfpower_list[] = {
 #if defined POWER_PA_SKY65383_11 || defined POWER_PA_MATEK_MR24_30 // Matek mR24-30
 #define POWER_PA_DEFINED
 
-#define POWER_GAIN_DBM            31 // gain of a PA stage if present
-#define POWER_SX1280_MAX_DBM      SX1280_POWER_0_DBM // maximum allowed sx power
-#define POWER_USE_DEFAULT_RFPOWER_CALC
+#include "../setup_types.h"
+
+// SX1280 power setting can vary from 0 to 31 which corresponds to -18 to 13 dBm
+void sx1280_rfpower_calc(const int8_t power_dbm, uint8_t* sx_power, int8_t* actual_power_dbm)
+{
+    if (power_dbm >= POWER_30_DBM) {
+        *sx_power = 17;
+        *actual_power_dbm = 30;
+    } else
+    if (power_dbm >= POWER_27_DBM) {
+        *sx_power = 12;
+        *actual_power_dbm = 27;
+    } else
+    if (power_dbm >= POWER_24_DBM) {
+        *sx_power = 8;
+        *actual_power_dbm = 24;
+    } else
+    if (power_dbm >= POWER_20_DBM) {
+        *sx_power = 4;
+        *actual_power_dbm = 20;
+    } else
+	if (power_dbm >= POWER_17_DBM) {
+		*sx_power = 1;
+		*actual_power_dbm = 17;
+	} else {
+        *sx_power = 0;
+        *actual_power_dbm = 16;
+    }
+}
 
 #define RFPOWER_DEFAULT           1 // index into rfpower_list array
 
 const rfpower_t rfpower_list[] = {
-    { .dbm = POWER_MIN, .mW = INT8_MIN },
+    { .dbm = POWER_17_DBM, .mW = 50 },
     { .dbm = POWER_20_DBM, .mW = 100 },
     { .dbm = POWER_24_DBM, .mW = 250 },
     { .dbm = POWER_27_DBM, .mW = 500 },

--- a/mLRS/Common/hal/hal-power-pa.h
+++ b/mLRS/Common/hal/hal-power-pa.h
@@ -73,7 +73,7 @@ const rfpower_t rfpower_list[] = {
 void sx1280_rfpower_calc(const int8_t power_dbm, uint8_t* sx_power, int8_t* actual_power_dbm)
 {
     if (power_dbm >= POWER_30_DBM) {
-        *sx_power = 17;
+        *sx_power = 19;
         *actual_power_dbm = 30;
     } else
     if (power_dbm >= POWER_27_DBM) {

--- a/mLRS/Common/sx-drivers/sx128x_driver.h
+++ b/mLRS/Common/sx-drivers/sx128x_driver.h
@@ -394,7 +394,11 @@ class Sx128xDriver : public Sx128xDriverCommon
 
     void RfPowerCalc(int8_t power_dbm, uint8_t* sx_power, int8_t* actual_power_dbm) override
     {
+#ifdef POWER_USE_DEFAULT_RFPOWER_CALC
         sx1280_rfpower_calc(power_dbm, sx_power, actual_power_dbm, POWER_GAIN_DBM, POWER_SX1280_MAX_DBM);
+#else
+        sx1280_rfpower_calc(power_dbm, sx_power, actual_power_dbm);
+#endif
     }
 
     //-- init API functions
@@ -541,8 +545,10 @@ class Sx128xDriver2 : public Sx128xDriverCommon
     {
 #ifdef DEVICE_HAS_DUAL_SX126x_SX128x
         sx1280_rfpower_calc(power_dbm, sx_power, actual_power_dbm, POWER2_GAIN_DBM, POWER2_SX1280_MAX_DBM);
-#else
+#elif POWER_USE_DEFAULT_RFPOWER_CALC
         sx1280_rfpower_calc(power_dbm, sx_power, actual_power_dbm, POWER_GAIN_DBM, POWER_SX1280_MAX_DBM);
+#else
+        sx1280_rfpower_calc(power_dbm, sx_power, actual_power_dbm);
 #endif
     }
 


### PR DESCRIPTION
- Adds power table for 65383
- 50 mW instead of min
- Tested on Matek mr24-30 Tx