### PR TITLE
Setup to flash backpack via standard tools

### DIFF
--- a/mLRS/Common/hal/esp/tx-hal-jumper-int-2400-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-jumper-int-2400-esp32.h
@@ -139,7 +139,7 @@ IRAM_ATTR void fan_set_power(int8_t power_dbm)
 
 #define ESP_RESET                 IO_P15 // backpack_en
 #define ESP_GPIO0                 IO_P2  // backpack_boot inverted?
-#define ESP_BOOT0                 IO_P0
+#define ESP_BOOT0                 IO_P0 // Will always be IO_P0
 
 uint8_t esp_boot0()
 {
@@ -148,6 +148,7 @@ uint8_t esp_boot0()
 
 void esp_init(void)
 {
+    // No need to configure ESP_BOOT0 which will always be IO_P0 and is pull-up by default
     gpio_init(ESP_GPIO0, IO_MODE_OUTPUT_PP_LOW); // high -> esp will start in bootloader mode
     gpio_init(ESP_RESET, IO_MODE_OUTPUT_PP_LOW); // low -> esp is in reset
 }

--- a/mLRS/Common/hal/esp/tx-hal-jumper-int-2400-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-jumper-int-2400-esp32.h
@@ -8,6 +8,7 @@
 
 //-------------------------------------------------------
 // ESP32, Jumper Tx Internal ELRS, good for T20, T20 V2, T15, T14, T-Pro S
+// Backpack: Generic ESP8266 Module, define LED_IO 16
 //-------------------------------------------------------
 
 // https://github.com/ExpressLRS/targets/blob/master/TX/Jumper%20T-20%202400.json
@@ -138,6 +139,12 @@ IRAM_ATTR void fan_set_power(int8_t power_dbm)
 
 #define ESP_RESET                 IO_P15 // backpack_en
 #define ESP_GPIO0                 IO_P2  // backpack_boot inverted?
+#define ESP_BOOT0                 IO_P0
+
+uint8_t esp_boot0()
+{
+    return gpio_read_activelow(ESP_BOOT0);
+}
 
 void esp_init(void)
 {

--- a/mLRS/Common/hal/esp/tx-hal-radiomaster-int-2400-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-radiomaster-int-2400-esp32.h
@@ -10,10 +10,9 @@
   Flashing ESP8285 backpack WiFi bridge:
   - Board: Generic ESP8266 Module, define LED_IO 16
   - First flash can be via web browser/ELRS WiFi
-  - Flash backpack before erasing ELRS or flash ELRS first using configurator via EdgeTx passthrough
   - Need ELRS version of esptool from https://github.com/ExpressLRS/Backpack
   - Power up radio, plug in USB, select VCP
-  - On Linux, run something like "Backpack/python/external/esptool/esptool.py --passthrough --port /dev/ttyACM0 --baud 460800 --before etx --after hard_reset write_flash 0x0000 ~/Arduino/build/mlrs-wireless-bridge-esp8266.ino.bin
+  - On Linux, run something like "Backpack/python/external/esptool/esptool.py --passthrough --port /dev/ttyACM0 --baud 115200 --before etx --after hard_reset write_flash 0x0000 ~/Arduino/build/mlrs-wireless-bridge-esp8266.ino.bin
 
   Flashing ESP32 module:
   - Need ELRS python folder from https://github.com/ExpressLRS/ExpressLRS
@@ -80,15 +79,15 @@
 #define UARTB_BAUD                TX_SERIAL_BAUDRATE
 #define UARTB_USE_TX_IO           IO_P17
 #define UARTB_USE_RX_IO           IO_P16
-#define UARTB_TXBUFSIZE           1024 // TX_SERIAL_TXBUFSIZE
+#define UARTB_TXBUFSIZE           TX_SERIAL_TXBUFSIZE
 #define UARTB_RXBUFSIZE           TX_SERIAL_RXBUFSIZE
 
 #define UART_USE_SERIAL1 // full duplex CRSF/MBridge (JR pin5)
 #define UART_BAUD                 400000
 #define UART_USE_TX_IO            IO_P1
 #define UART_USE_RX_IO            IO_P3
-#define UART_TXBUFSIZE            512 //0 // 128 fifo should be sufficient // 512
-#define UART_RXBUFSIZE            512
+#define UART_TXBUFSIZE            TX_SERIAL_TXBUFSIZE
+#define UART_RXBUFSIZE            TX_SERIAL_RXBUFSIZE // 512
 
 #define UARTF_USE_SERIAL2 // debug
 #define UARTF_BAUD                115200
@@ -154,18 +153,18 @@ void sx_dio_exti_isr_clearflag(void) {}
 //-- Button
 // Not normally used since this is inside the radio
 
-#define BUTTON                    IO_P0
+//#define BUTTON                    IO_P0
 
 void button_init(void)
 {
-    gpio_init(BUTTON, IO_MODE_INPUT_PU);
+    //gpio_init(BUTTON, IO_MODE_INPUT_PU);
 }
 
 IRAM_ATTR bool button_pressed(void)
 {
-    return gpio_read_activelow(BUTTON) ? true : false;
+    //return gpio_read_activelow(BUTTON) ? true : false;
+    return false;
 }
-
 
 //-- LEDs
 
@@ -184,9 +183,15 @@ IRAM_ATTR void led_red_toggle(void) { gpio_toggle(LED_RED); }
 //-- ESP32 Wifi Bridge
 
 #ifdef DEVICE_HAS_ESP_WIFI_BRIDGE_ON_SERIAL
-
+#define ESP_BOOT0                 IO_P0
 #define ESP_RESET                 IO_P25 // backpack_en
 #define ESP_GPIO0                 IO_P15 // backpack_boot inverted?
+
+uint8_t esp_boot0()
+{
+    return gpio_read_activelow(ESP_BOOT0);
+}
+
 
 void esp_init(void)
 {

--- a/mLRS/Common/hal/esp/tx-hal-radiomaster-int-2400-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-radiomaster-int-2400-esp32.h
@@ -183,9 +183,10 @@ IRAM_ATTR void led_red_toggle(void) { gpio_toggle(LED_RED); }
 //-- ESP32 Wifi Bridge
 
 #ifdef DEVICE_HAS_ESP_WIFI_BRIDGE_ON_SERIAL
-#define ESP_BOOT0                 IO_P0
+
 #define ESP_RESET                 IO_P25 // backpack_en
 #define ESP_GPIO0                 IO_P15 // backpack_boot inverted?
+#define ESP_BOOT0                 IO_P0 // Will always be IO_P0
 
 uint8_t esp_boot0()
 {
@@ -195,6 +196,7 @@ uint8_t esp_boot0()
 
 void esp_init(void)
 {
+    // No need to configure ESP_BOOT0 which will always be IO_P0 and is pull-up by default
     gpio_init(ESP_GPIO0, IO_MODE_OUTPUT_PP_LOW); // high -> esp will start in bootloader mode
     gpio_init(ESP_RESET, IO_MODE_OUTPUT_PP_LOW); // low -> esp is in reset
 }

--- a/mLRS/CommonTx/esp.h
+++ b/mLRS/CommonTx/esp.h
@@ -215,6 +215,7 @@ void tTxEspWifiBridge::passthrough_do_flashing(void)
 {
 #if defined USE_ESP_WIFI_BRIDGE_RST_GPIO0 && (defined USE_ESP_WIFI_BRIDGE_DTR_RTS || defined USE_ESP_WIFI_BRIDGE_BOOT0)
     uint32_t serial_tlast_ms = millis32();
+    uint32_t baudrate = 115200; // Note: this is what is used for flashing, can be different to ESP_CONFIGURE setting
 
     disp.DrawNotify("ESP\nFLASHING");
     delay_ms(50); // give display some time
@@ -227,12 +228,12 @@ void tTxEspWifiBridge::passthrough_do_flashing(void)
     delay_ms(100); // 10 ms is too short, ESP8285 needs more time
     esp_gpio0_high();
     delay_ms(10);
+    com->SetBaudRate(baudrate); // Standard tools should specify 115200 to avoid baudrate change
 #endif
 
+    ser->SetBaudRate(baudrate);
     leds.InitPassthrough();
 
-    uint32_t baudrate = 115200; // Note: this is what is used for flashing, can be different to ESP_CONFIGURE setting
-    ser->SetBaudRate(baudrate);
     ser->flush();
     com->flush();
 
@@ -266,6 +267,7 @@ void tTxEspWifiBridge::passthrough_do_flashing(void)
             cnt++;
         }
 
+#ifndef USE_ESP_WIFI_BRIDGE_BOOT0
         if (tnow_ms - serial_tlast_ms > ESP_PASSTHROUGH_TMO_MS) {
             // reset ESP
             esp_reset_low();
@@ -275,6 +277,7 @@ void tTxEspWifiBridge::passthrough_do_flashing(void)
             disp.DrawNotify("");
             return;
         }
+#endif
 
     }
 #endif // USE_ESP_WIFI_BRIDGE_RST_GPIO0 && (USE_ESP_WIFI_BRIDGE_DTR_RTS || USE_ESP_WIFI_BRIDGE_BOOT0)

--- a/mLRS/CommonTx/esp.h
+++ b/mLRS/CommonTx/esp.h
@@ -215,7 +215,6 @@ void tTxEspWifiBridge::passthrough_do_flashing(void)
 {
 #if defined USE_ESP_WIFI_BRIDGE_RST_GPIO0 && (defined USE_ESP_WIFI_BRIDGE_DTR_RTS || defined USE_ESP_WIFI_BRIDGE_BOOT0)
     uint32_t serial_tlast_ms = millis32();
-    uint32_t baudrate = 115200; // Note: this is what is used for flashing, can be different to ESP_CONFIGURE setting
 
     disp.DrawNotify("ESP\nFLASHING");
     delay_ms(50); // give display some time
@@ -228,12 +227,13 @@ void tTxEspWifiBridge::passthrough_do_flashing(void)
     delay_ms(100); // 10 ms is too short, ESP8285 needs more time
     esp_gpio0_high();
     delay_ms(10);
-    com->SetBaudRate(baudrate); // Standard tools should specify 115200 to avoid baudrate change
 #endif
 
-    ser->SetBaudRate(baudrate);
     leds.InitPassthrough();
 
+    uint32_t baudrate = 115200; // Note: this is what is used for flashing, can be different to ESP_CONFIGURE setting
+    ser->SetBaudRate(baudrate);
+    com->SetBaudRate(baudrate); // Standard tools should specify 115200 to avoid baudrate change
     ser->flush();
     com->flush();
 


### PR DESCRIPTION
after configuring passthrough using EdgeTx CLI

Define esp_boot0() for internal Tx modules

This has been tested with 2.4 GHz internal Tx modules on Radiomaster Pocket and Jumper T15 using ETXinitPassthrough.py which will be coming in a separate PR.

It also works with the ELRS version of esptool.