### PR TITLE
Esp jrpin5 external

### DIFF
--- a/mLRS/Common/esp-lib/esp-uart-template.h
+++ b/mLRS/Common/esp-lib/esp-uart-template.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UART$_TXBUFSIZE > 0) && (UART$_TXBUFSIZE < 256)
     #error UART$_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
-    #error UART_TXBUFSIZE must be 0 or >= 256
+  #if (UART$_RXBUFSIZE > 0) && (UART$_RXBUFSIZE < 256)
+    #error UART$_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uart-template.h
+++ b/mLRS/Common/esp-lib/esp-uart-template.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UART$_TXBUFSIZE > 0) && (UART$_TXBUFSIZE < 256)
     #error UART$_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UART$_RXBUFSIZE < 256)
-    #error UART$_RXBUFSIZE must be >= 256
+  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
+    #error UART_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uart.h
+++ b/mLRS/Common/esp-lib/esp-uart.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UART_TXBUFSIZE > 0) && (UART_TXBUFSIZE < 256)
     #error UART_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UART_RXBUFSIZE < 256)
-    #error UART_RXBUFSIZE must be >= 256
+  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
+    #error UART_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uartb.h
+++ b/mLRS/Common/esp-lib/esp-uartb.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UARTB_TXBUFSIZE > 0) && (UARTB_TXBUFSIZE < 256)
     #error UARTB_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UARTB_RXBUFSIZE < 256)
-    #error UARTB_RXBUFSIZE must be >= 256
+  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
+    #error UART_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uartb.h
+++ b/mLRS/Common/esp-lib/esp-uartb.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UARTB_TXBUFSIZE > 0) && (UARTB_TXBUFSIZE < 256)
     #error UARTB_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
-    #error UART_TXBUFSIZE must be 0 or >= 256
+  #if (UARTB_RXBUFSIZE > 0) && (UARTB_RXBUFSIZE < 256)
+    #error UARTB_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uartc.h
+++ b/mLRS/Common/esp-lib/esp-uartc.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UARTC_TXBUFSIZE > 0) && (UARTC_TXBUFSIZE < 256)
     #error UARTC_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
-    #error UART_TXBUFSIZE must be 0 or >= 256
+  #if (UARTC_RXBUFSIZE > 0) && (UARTC_RXBUFSIZE < 256)
+    #error UARTC_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uartc.h
+++ b/mLRS/Common/esp-lib/esp-uartc.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UARTC_TXBUFSIZE > 0) && (UARTC_TXBUFSIZE < 256)
     #error UARTC_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UARTC_RXBUFSIZE < 256)
-    #error UARTC_RXBUFSIZE must be >= 256
+  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
+    #error UART_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uartd.h
+++ b/mLRS/Common/esp-lib/esp-uartd.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UARTD_TXBUFSIZE > 0) && (UARTD_TXBUFSIZE < 256)
     #error UARTD_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
-    #error UART_TXBUFSIZE must be 0 or >= 256
+  #if (UARTD_RXBUFSIZE > 0) && (UARTD_RXBUFSIZE < 256)
+    #error UARTD_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uartd.h
+++ b/mLRS/Common/esp-lib/esp-uartd.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UARTD_TXBUFSIZE > 0) && (UARTD_TXBUFSIZE < 256)
     #error UARTD_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UARTD_RXBUFSIZE < 256)
-    #error UARTD_RXBUFSIZE must be >= 256
+  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
+    #error UART_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uarte.h
+++ b/mLRS/Common/esp-lib/esp-uarte.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UARTE_TXBUFSIZE > 0) && (UARTE_TXBUFSIZE < 256)
     #error UARTE_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UARTE_RXBUFSIZE < 256)
-    #error UARTE_RXBUFSIZE must be >= 256
+  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
+    #error UART_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uarte.h
+++ b/mLRS/Common/esp-lib/esp-uarte.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UARTE_TXBUFSIZE > 0) && (UARTE_TXBUFSIZE < 256)
     #error UARTE_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
-    #error UART_TXBUFSIZE must be 0 or >= 256
+  #if (UARTE_RXBUFSIZE > 0) && (UARTE_RXBUFSIZE < 256)
+    #error UARTE_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uartf.h
+++ b/mLRS/Common/esp-lib/esp-uartf.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UARTF_TXBUFSIZE > 0) && (UARTF_TXBUFSIZE < 256)
     #error UARTF_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UARTF_RXBUFSIZE < 256)
-    #error UARTF_RXBUFSIZE must be >= 256
+  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
+    #error UART_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/esp-lib/esp-uartf.h
+++ b/mLRS/Common/esp-lib/esp-uartf.h
@@ -59,8 +59,8 @@ typedef enum {
   #if (UARTF_TXBUFSIZE > 0) && (UARTF_TXBUFSIZE < 256)
     #error UARTF_TXBUFSIZE must be 0 or >= 256
   #endif
-  #if (UART_RXBUFSIZE > 0) && (UART_RXBUFSIZE < 256)
-    #error UART_TXBUFSIZE must be 0 or >= 256
+  #if (UARTF_RXBUFSIZE > 0) && (UARTF_RXBUFSIZE < 256)
+    #error UARTF_TXBUFSIZE must be 0 or >= 256
   #endif
 #endif
 

--- a/mLRS/Common/hal/esp/tx-hal-jumper-int-2400-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-jumper-int-2400-esp32.h
@@ -14,7 +14,7 @@
 // https://github.com/ExpressLRS/targets/blob/master/TX/Jumper%20T-20%202400.json
 // Added fan on GPIO 33
 
-#define DEVICE_HAS_JRPIN5_NO_TC
+#define DEVICE_HAS_JRPIN5
 #define DEVICE_HAS_NO_LED
 #define DEVICE_HAS_NO_COM
 #define DEVICE_HAS_NO_DEBUG
@@ -44,6 +44,7 @@
 #define UART_TXBUFSIZE            0 // TX_SERIAL_TXBUFSIZE  // 512
 #define UART_RXBUFSIZE            0 // TX_SERIAL_RXBUFSIZE  // 2048
 
+#define JR_PIN5_FULL_DUPLEX       // Internal module
 
 //-- SX1: SX12xx & SPI
 

--- a/mLRS/Common/hal/esp/tx-hal-jumper-int-2400-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-jumper-int-2400-esp32.h
@@ -14,7 +14,7 @@
 // https://github.com/ExpressLRS/targets/blob/master/TX/Jumper%20T-20%202400.json
 // Added fan on GPIO 33
 
-#define DEVICE_HAS_JRPIN5_FULL_DUPLEX
+#define DEVICE_HAS_JRPIN5_NO_TC
 #define DEVICE_HAS_NO_LED
 #define DEVICE_HAS_NO_COM
 #define DEVICE_HAS_NO_DEBUG
@@ -41,8 +41,8 @@
 #define UART_BAUD                 400000
 #define UART_USE_TX_IO            IO_P1
 #define UART_USE_RX_IO            IO_P3
-#define UART_TXBUFSIZE            TX_SERIAL_TXBUFSIZE  // 512
-#define UART_RXBUFSIZE            TX_SERIAL_RXBUFSIZE  // 2048
+#define UART_TXBUFSIZE            0 // TX_SERIAL_TXBUFSIZE  // 512
+#define UART_RXBUFSIZE            0 // TX_SERIAL_RXBUFSIZE  // 2048
 
 
 //-- SX1: SX12xx & SPI

--- a/mLRS/Common/hal/esp/tx-hal-jumper-int-900-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-jumper-int-900-esp32.h
@@ -13,7 +13,7 @@
 
 // https://github.com/ExpressLRS/targets/blob/master/TX/Jumper%20T-20%20900%20V2.json
 
-#define DEVICE_HAS_JRPIN5_NO_TC
+#define DEVICE_HAS_JRPIN5
 #define DEVICE_HAS_NO_LED
 #define DEVICE_HAS_NO_COM
 #define DEVICE_HAS_NO_DEBUG
@@ -43,6 +43,7 @@
 #define UART_TXBUFSIZE            0 // TX_SERIAL_TXBUFSIZE  // 512
 #define UART_RXBUFSIZE            0 // TX_SERIAL_RXBUFSIZE  // 2048
 
+#define JR_PIN5_FULL_DUPLEX       // Internal module
 
 //-- SX1: SX12xx & SPI
 

--- a/mLRS/Common/hal/esp/tx-hal-jumper-int-900-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-jumper-int-900-esp32.h
@@ -13,7 +13,7 @@
 
 // https://github.com/ExpressLRS/targets/blob/master/TX/Jumper%20T-20%20900%20V2.json
 
-#define DEVICE_HAS_JRPIN5_FULL_DUPLEX
+#define DEVICE_HAS_JRPIN5_NO_TC
 #define DEVICE_HAS_NO_LED
 #define DEVICE_HAS_NO_COM
 #define DEVICE_HAS_NO_DEBUG
@@ -40,8 +40,8 @@
 #define UART_BAUD                 400000
 #define UART_USE_TX_IO            IO_P1
 #define UART_USE_RX_IO            IO_P3
-#define UART_TXBUFSIZE            TX_SERIAL_TXBUFSIZE  // 512
-#define UART_RXBUFSIZE            TX_SERIAL_RXBUFSIZE  // 2048
+#define UART_TXBUFSIZE            0 // TX_SERIAL_TXBUFSIZE  // 512
+#define UART_RXBUFSIZE            0 // TX_SERIAL_RXBUFSIZE  // 2048
 
 
 //-- SX1: SX12xx & SPI

--- a/mLRS/Common/hal/esp/tx-hal-radiomaster-bandit-series-900-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-radiomaster-bandit-series-900-esp32.h
@@ -59,7 +59,7 @@
 */
 
 
-#define DEVICE_HAS_JRPIN5_NO_TC
+#define DEVICE_HAS_JRPIN5
 //#define DEVICE_HAS_IN
 //#define DEVICE_HAS_SERIAL_OR_COM // board has UART which is shared between Serial or Com, selected by e.g. a switch
 #define DEVICE_HAS_NO_SERIAL

--- a/mLRS/Common/hal/esp/tx-hal-radiomaster-bandit-series-900-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-radiomaster-bandit-series-900-esp32.h
@@ -6,8 +6,6 @@
 // hal
 //*******************************************************
 
-// FOR SiK TELEM USE ONLY !
-
 /*
   Flashing ESP8285:
   - change ser dest to serial2
@@ -61,12 +59,12 @@
 */
 
 
-//#define DEVICE_HAS_JRPIN5
+#define DEVICE_HAS_JRPIN5_NO_TC
 //#define DEVICE_HAS_IN
-#define DEVICE_HAS_SERIAL_OR_COM // board has UART which is shared between Serial or Com, selected by e.g. a switch
-//#define DEVICE_HAS_NO_SERIAL
-//#define DEVICE_HAS_NO_COM
-#define DEVICE_HAS_NO_DEBUG
+//#define DEVICE_HAS_SERIAL_OR_COM // board has UART which is shared between Serial or Com, selected by e.g. a switch
+#define DEVICE_HAS_NO_SERIAL
+#define DEVICE_HAS_NO_COM
+//#define DEVICE_HAS_NO_DEBUG
 
 #ifdef TX_ELRS_RADIOMASTER_BANDIT_900_ESP32
 #define DEVICE_HAS_I2C_DISPLAY
@@ -99,16 +97,23 @@
 #define UARTC_TXBUFSIZE           0 // ?? // TX_COM_TXBUFSIZE
 #define UARTC_RXBUFSIZE           TX_COM_RXBUFSIZE
 
-#define UARTD_USE_SERIAL1 // serial2 BT/ESP
+#define UARTD_USE_SERIAL2 // serial2 BT/ESP
 #define UARTD_BAUD                115200
 #define UARTD_USE_TX_IO           IO_P17
 #define UARTD_USE_RX_IO           IO_P16
 #define UARTD_TXBUFSIZE           1024 // TX_SERIAL_TXBUFSIZE
 #define UARTD_RXBUFSIZE           TX_SERIAL_RXBUFSIZE
 
-#define UARTF_USE_SERIAL2 // debug is on JRPin5
+#define UART_USE_SERIAL1 // full duplex CRSF/MBridge (JR pin5)
+#define UART_BAUD                 400000
+#define UART_USE_TX_IO            IO_P13
+#define UART_USE_RX_IO            IO_P13
+#define UART_TXBUFSIZE            0 // 512 // 128 fifo should be sufficient
+#define UART_RXBUFSIZE            0 // 512
+
+#define UARTF_USE_SERIAL // debug is on RT
 #define UARTF_BAUD                115200
-#define UARTF_USE_TX_IO           IO_P13
+#define UARTF_USE_TX_IO           IO_P1
 #define UARTF_USE_RX_IO           -1
 #define UARTF_TXBUFSIZE           512 // ?? // 512
 

--- a/mLRS/Common/hal/esp/tx-hal-radiomaster-int-2400-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-radiomaster-int-2400-esp32.h
@@ -60,7 +60,7 @@
 */
 
 
-#define DEVICE_HAS_JRPIN5_FULL_DUPLEX
+#define DEVICE_HAS_JRPIN5_NO_TC
 #define DEVICE_HAS_SINGLE_LED
 #define DEVICE_HAS_NO_COM
 //#define DEVICE_HAS_NO_DEBUG
@@ -86,8 +86,8 @@
 #define UART_BAUD                 400000
 #define UART_USE_TX_IO            IO_P1
 #define UART_USE_RX_IO            IO_P3
-#define UART_TXBUFSIZE            TX_SERIAL_TXBUFSIZE
-#define UART_RXBUFSIZE            TX_SERIAL_RXBUFSIZE // 512
+#define UART_TXBUFSIZE            0 // TX_SERIAL_TXBUFSIZE
+#define UART_RXBUFSIZE            0 // TX_SERIAL_RXBUFSIZE // 512
 
 #define UARTF_USE_SERIAL2 // debug
 #define UARTF_BAUD                115200

--- a/mLRS/Common/hal/esp/tx-hal-radiomaster-int-2400-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-radiomaster-int-2400-esp32.h
@@ -60,7 +60,7 @@
 */
 
 
-#define DEVICE_HAS_JRPIN5_NO_TC
+#define DEVICE_HAS_JRPIN5
 #define DEVICE_HAS_SINGLE_LED
 #define DEVICE_HAS_NO_COM
 //#define DEVICE_HAS_NO_DEBUG
@@ -88,6 +88,8 @@
 #define UART_USE_RX_IO            IO_P3
 #define UART_TXBUFSIZE            0 // TX_SERIAL_TXBUFSIZE
 #define UART_RXBUFSIZE            0 // TX_SERIAL_RXBUFSIZE // 512
+
+#define JR_PIN5_FULL_DUPLEX       // Internal module
 
 #define UARTF_USE_SERIAL2 // debug
 #define UARTF_BAUD                115200

--- a/mLRS/Common/hal/hal.h
+++ b/mLRS/Common/hal/hal.h
@@ -39,8 +39,8 @@ following for the tx-hal and rx-hal files.
 In tx-hal files:
 
 #define DEVICE_HAS_DIVERSITY        // board supports diversity
-#define DEVICE_HAS_JRPIN5           // board has a pin for JR bay Pin5/SPort
-#define DEVICE_HAS_JRPIN5_FULL_DUPLEX   // board has full duplex uart for JR bay Pin5 function
+#define DEVICE_HAS_JRPIN5           // board has a pin for JR bay Pin5/SPort with tc interrupt
+#define DEVICE_HAS_JRPIN5_NO_TC     // board has half or full duplex uart for JR bay Pin5 function but no tc interrupt
 #define DEVICE_HAS_IN               // board has an IN port, which supports both normal and inverted UART signals
 #define DEVICE_HAS_IN_NORMAL        // board has an IN port, which supports only normal UART signals
 #define DEVICE_HAS_IN_INVERTED      // board has an IN port, which supports only inverted UART signals
@@ -323,7 +323,7 @@ Note: Some "high-level" features are set for each device in the device_conf.h fi
 #endif // DEVICE_IS_TRANSMITTER
 
 
-#if defined DEVICE_HAS_JRPIN5 || defined DEVICE_HAS_JRPIN5_FULL_DUPLEX
+#if defined DEVICE_HAS_JRPIN5 || defined DEVICE_HAS_JRPIN5_NO_TC
    #define USE_JRPIN5
 #endif
 

--- a/mLRS/Common/hal/hal.h
+++ b/mLRS/Common/hal/hal.h
@@ -40,7 +40,6 @@ In tx-hal files:
 
 #define DEVICE_HAS_DIVERSITY        // board supports diversity
 #define DEVICE_HAS_JRPIN5           // board has a pin for JR bay Pin5/SPort with tc interrupt
-#define DEVICE_HAS_JRPIN5_NO_TC     // board has half or full duplex uart for JR bay Pin5 function but no tc interrupt
 #define DEVICE_HAS_IN               // board has an IN port, which supports both normal and inverted UART signals
 #define DEVICE_HAS_IN_NORMAL        // board has an IN port, which supports only normal UART signals
 #define DEVICE_HAS_IN_INVERTED      // board has an IN port, which supports only inverted UART signals
@@ -323,7 +322,7 @@ Note: Some "high-level" features are set for each device in the device_conf.h fi
 #endif // DEVICE_IS_TRANSMITTER
 
 
-#if defined DEVICE_HAS_JRPIN5 || defined DEVICE_HAS_JRPIN5_NO_TC
+#if defined DEVICE_HAS_JRPIN5
    #define USE_JRPIN5
 #endif
 

--- a/mLRS/CommonTx/crsf_interface_tx.h
+++ b/mLRS/CommonTx/crsf_interface_tx.h
@@ -173,7 +173,7 @@ bool tTxCrsf::transmit_start(void)
 // a frame is sent every 4 ms, frame length is max 64 bytes
 // a byte is 25 us
 // gaps between frames are 3 ms or so
-#define CRSF_PARSE_NEXTCHAR_TMO_US  2200 // Lots of jitter when polled.
+#define CRSF_PARSE_NEXTCHAR_TMO_US  500
 
 
 // CRSF frame format:
@@ -200,6 +200,7 @@ void tTxCrsf::parse_nextchar(uint8_t c)
             cnt = 0;
             frame[cnt++] = c;
             state = STATE_RECEIVE_CRSF_LEN;
+#ifdef USE_DEBUG
             if (discarded) {
                 if (discarded > 1) {
                     dbg.puts(u16toBCD_s(discarded));
@@ -211,6 +212,7 @@ void tTxCrsf::parse_nextchar(uint8_t c)
         else {
             // Detect discarded bytes
             discarded++;
+#endif
         }
         break;
 

--- a/mLRS/CommonTx/crsf_interface_tx.h
+++ b/mLRS/CommonTx/crsf_interface_tx.h
@@ -172,7 +172,7 @@ bool tTxCrsf::transmit_start(void)
 
 // a frame is sent every 4 ms, frame length is max 64 bytes
 // a byte is 25 us
-// gaps between frames are 3 ms or so
+// The gaps between received frames are at least 2.4 ms
 #define CRSF_PARSE_NEXTCHAR_TMO_US  500
 
 
@@ -208,12 +208,14 @@ void tTxCrsf::parse_nextchar(uint8_t c)
                 }
                 discarded = 0;
             }
+#endif
         }
+#ifdef USE_DEBUG
         else {
             // Detect discarded bytes
             discarded++;
-#endif
         }
+#endif
         break;
 
     case STATE_RECEIVE_CRSF_LEN:

--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -63,8 +63,8 @@ void (*uart_tc_callback_ptr)(void) = &uart_tc_callback_dummy;
 #define UART_RX_CALLBACK_FULL(c)    (*uart_rx_callback_ptr)(c)
 #define UART_TC_CALLBACK()          (*uart_tc_callback_ptr)()
 
-#ifdef DEVICE_HAS_JRPIN5_FULL_DUPLEX
-#include "jr_pin5_interface_full_duplex.h"
+#ifdef DEVICE_HAS_JRPIN5_NO_TC
+#include "jr_pin5_interface_no_tc.h"
 #else
 #include "../modules/stm32ll-lib/src/stdstm32-uart.h"
 
@@ -123,9 +123,6 @@ class tPin5BridgeBase
     void pin5_rx_callback(uint8_t c);
     void pin5_tc_callback(void);
 
-    // asynchronous uart handler
-    void pin5_do(void);
-
     // parser
     typedef enum {
         STATE_IDLE = 0,
@@ -153,6 +150,7 @@ class tPin5BridgeBase
     uint8_t len;
     uint8_t cnt;
     uint16_t tlast_us;
+    uint16_t discarded;
 
     // check and rescue
     // the FRM303 can get stuck, whatever we tried, so brutal rescue
@@ -168,6 +166,7 @@ void tPin5BridgeBase::Init(void)
     len = 0;
     cnt = 0;
     tlast_us = 0;
+    discarded = 0;
 
     telemetry_start_next_tick = false;
     telemetry_state = 0;
@@ -357,16 +356,6 @@ void tPin5BridgeBase::pin5_tc_callback(void)
 
 
 //-------------------------------------------------------
-// Pin5 asynchronous uart handler
-// polled in Crsf or mBridge ChannelsUpdated()
-
-void tPin5BridgeBase::pin5_do(void)
-{
-    // not used on STM32
-}
-
-
-//-------------------------------------------------------
 // Check and rescue
 // a good place to call it could be ChannelsUpdated()
 // Note: For the FRM303 it was observed that the TC callback may be missed in the uart isr, basically when
@@ -397,6 +386,6 @@ void tPin5BridgeBase::CheckAndRescue(void)
 }
 
 
-#endif // !DEVICE_HAS_JRPIN5_FULL_DUPLEX
+#endif // !DEVICE_HAS_JRPIN5_NO_TC
 
 #endif // JRPIN5_INTERFACE_H

--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -63,8 +63,8 @@ void (*uart_tc_callback_ptr)(void) = &uart_tc_callback_dummy;
 #define UART_RX_CALLBACK_FULL(c)    (*uart_rx_callback_ptr)(c)
 #define UART_TC_CALLBACK()          (*uart_tc_callback_ptr)()
 
-#ifdef DEVICE_HAS_JRPIN5_NO_TC
-#include "jr_pin5_interface_no_tc.h"
+#if defined ESP8266 || defined ESP32
+#include "jr_pin5_interface_esp.h"
 #else
 #include "../modules/stm32ll-lib/src/stdstm32-uart.h"
 

--- a/mLRS/CommonTx/jr_pin5_interface.h
+++ b/mLRS/CommonTx/jr_pin5_interface.h
@@ -386,6 +386,6 @@ void tPin5BridgeBase::CheckAndRescue(void)
 }
 
 
-#endif // !DEVICE_HAS_JRPIN5_NO_TC
+#endif // !(defined ESP8266 || defined ESP32) 
 
 #endif // JRPIN5_INTERFACE_H

--- a/mLRS/CommonTx/jr_pin5_interface_esp.h
+++ b/mLRS/CommonTx/jr_pin5_interface_esp.h
@@ -95,7 +95,7 @@ void tPin5BridgeBase::Init(void)
     UART_SERIAL_NO.setRxFIFOFull(64);
     UART_SERIAL_NO.onReceive((void (*)(void)) uart_rx_callback_ptr, false);
     
-#ifdef JR_PIN5_FULL_DUPLEX
+#ifndef JR_PIN5_FULL_DUPLEX
 
 #ifdef UART_USE_SERIAL
   #define UART_SERIAL_NO       Serial
@@ -109,8 +109,8 @@ void tPin5BridgeBase::Init(void)
     UART_SERIAL_NO.setMode(MODE_RS485_HALF_DUPLEX);
 
     gpio_matrix_in((gpio_num_t)UART_USE_TX_IO, U1RXD_IN_IDX, true);
-    gpio_pulldown_en((gpio_num_t)UART_USE_TX_IO);
-    gpio_pullup_dis((gpio_num_t)UART_USE_TX_IO);
+    gpio_pulldown_dis((gpio_num_t)UART_USE_TX_IO);  // Should be pulldown if we had inverted open drain
+    gpio_pullup_dis((gpio_num_t)UART_USE_TX_IO); // But would pulup help?
 
     gpio_set_level((gpio_num_t)UART_USE_TX_IO, 0);
     gpio_set_direction((gpio_num_t)UART_USE_TX_IO, GPIO_MODE_INPUT_OUTPUT);

--- a/mLRS/CommonTx/jr_pin5_interface_no_tc.h
+++ b/mLRS/CommonTx/jr_pin5_interface_no_tc.h
@@ -151,7 +151,6 @@ void tPin5BridgeBase::pin5_tx_enable(bool enable_flag)
 
 void tPin5BridgeBase::pin5_rx_callback(uint8_t c)
 {
-    TS_START(0);
     // poll uart
     while (uart_rx_available() && state != STATE_TRANSMIT_START) { // read at most 1 message
         parse_nextchar(uart_getc());
@@ -162,7 +161,6 @@ void tPin5BridgeBase::pin5_rx_callback(uint8_t c)
         transmit_start();
         state = STATE_IDLE;
     }
-    TS_END(0);
 }
 
 

--- a/mLRS/CommonTx/mbridge_interface.h
+++ b/mLRS/CommonTx/mbridge_interface.h
@@ -184,12 +184,14 @@ void tMBridge::parse_nextchar(uint8_t c)
                 }
                 discarded = 0;
             }
+#endif
         }
+#ifdef USE_DEBUG
         else {
             // Detect discarded bytes
             discarded++;
-#endif
         }
+#endif
         break;
 
     case STATE_RECEIVE_MBRIDGE_STX2:

--- a/mLRS/CommonTx/mbridge_interface.h
+++ b/mLRS/CommonTx/mbridge_interface.h
@@ -176,6 +176,7 @@ void tMBridge::parse_nextchar(uint8_t c)
     case STATE_IDLE:
         if (c == MBRIDGE_STX1) {
             state = STATE_RECEIVE_MBRIDGE_STX2;
+#ifdef USE_DEBUG
             if (discarded) {
                 if (discarded > 1) {
                     dbg.puts(u16toBCD_s(discarded));
@@ -187,6 +188,7 @@ void tMBridge::parse_nextchar(uint8_t c)
         else {
             // Detect discarded bytes
             discarded++;
+#endif
         }
         break;
 

--- a/mLRS/CommonTx/mbridge_interface.h
+++ b/mLRS/CommonTx/mbridge_interface.h
@@ -174,7 +174,20 @@ void tMBridge::parse_nextchar(uint8_t c)
 
     switch (state) {
     case STATE_IDLE:
-        if (c == MBRIDGE_STX1) state = STATE_RECEIVE_MBRIDGE_STX2;
+        if (c == MBRIDGE_STX1) {
+            state = STATE_RECEIVE_MBRIDGE_STX2;
+            if (discarded) {
+                if (discarded > 1) {
+                    dbg.puts(u16toBCD_s(discarded));
+                    dbg.puts(" bytes lost!\n");
+                }
+                discarded = 0;
+            }
+        }
+        else {
+            // Detect discarded bytes
+            discarded++;
+        }
         break;
 
     case STATE_RECEIVE_MBRIDGE_STX2:
@@ -338,8 +351,6 @@ bool tMBridge::ChannelsUpdated(tRcData* const rc)
     if (crsf_emulation) return false; // CRSF: just don't ever do it, should not happen
 
     if (!enabled) return false;
-
-    pin5_do();
 
     CheckAndRescue();
 

--- a/mLRS/CommonTx/mlrs-tx.cpp
+++ b/mLRS/CommonTx/mlrs-tx.cpp
@@ -113,7 +113,7 @@
 #include "../Common/diversity.h"
 #include "../Common/arq.h"
 #include "../Common/rf_power.h"
-//#include "../Common/time_stats.h" // un-comment if you want to use
+#include "../Common/time_stats.h" // un-comment if you want to use
 //#include "../Common/test.h" // un-comment if you want to compile for board test
 
 #include "config_id.h"
@@ -698,6 +698,7 @@ bool connected_and_rx_setup_available(void)
 
 void main_loop(void)
 {
+    TS_END(9, 10000, true);
 #ifdef BOARD_TEST_H
     main_test();
 #endif
@@ -752,7 +753,7 @@ RESTARTCONTROLLER
     sx_serial.Init(&serial, &mbridge, &serial2); // ports selected by SerialDestination, ChannelsSource
     cli.Init(&comport);
 #ifdef USE_ESP_WIFI_BRIDGE
-  #ifdef DEVICE_HAS_JRPIN5_FULL_DUPLEX
+  #if defined DEVICE_HAS_JRPIN5_NO_TC && UART_USE_TX_IO != UART_USE_RX_IO
     esp.Init(&jrpin5serial, &serial, &serial2, Config.SerialBaudrate, &Setup.Tx[Config.ConfigId]);
   #else
     esp.Init(&comport, &serial, &serial2, Config.SerialBaudrate, &Setup.Tx[Config.ConfigId]);

--- a/mLRS/CommonTx/mlrs-tx.cpp
+++ b/mLRS/CommonTx/mlrs-tx.cpp
@@ -752,7 +752,7 @@ RESTARTCONTROLLER
     sx_serial.Init(&serial, &mbridge, &serial2); // ports selected by SerialDestination, ChannelsSource
     cli.Init(&comport);
 #ifdef USE_ESP_WIFI_BRIDGE
-  #if defined DEVICE_HAS_JRPIN5_NO_TC && UART_USE_TX_IO != UART_USE_RX_IO
+  #if defined JR_PIN5_FULL_DUPLEX
     esp.Init(&jrpin5serial, &serial, &serial2, Config.SerialBaudrate, &Setup.Tx[Config.ConfigId]);
   #else
     esp.Init(&comport, &serial, &serial2, Config.SerialBaudrate, &Setup.Tx[Config.ConfigId]);

--- a/mLRS/CommonTx/mlrs-tx.cpp
+++ b/mLRS/CommonTx/mlrs-tx.cpp
@@ -113,7 +113,7 @@
 #include "../Common/diversity.h"
 #include "../Common/arq.h"
 #include "../Common/rf_power.h"
-#include "../Common/time_stats.h" // un-comment if you want to use
+//#include "../Common/time_stats.h" // un-comment if you want to use
 //#include "../Common/test.h" // un-comment if you want to compile for board test
 
 #include "config_id.h"
@@ -698,7 +698,6 @@ bool connected_and_rx_setup_available(void)
 
 void main_loop(void)
 {
-    TS_END(9, 10000, true);
 #ifdef BOARD_TEST_H
     main_test();
 #endif


### PR DESCRIPTION
Half duplex JRpin5 for esp32
    Leverage esp32 serial MODE_RS485_HALF_DUPLEX and GPIO_DRIVE_CAP_0 to work around the missing TC interrupt for JRpin5.
