### PR TITLE
tx, cli delay tweak

### DIFF
--- a/mLRS/CommonTx/cli.h
+++ b/mLRS/CommonTx/cli.h
@@ -313,7 +313,7 @@ class tTxCli
 #elif !defined DEVICE_HAS_COM_ON_USB && (UARTC_TXBUFSIZE >= 2048)
     void delay(void) {}
 #else
-    void delay(void) { if (put_cnt > 192) { delay_ms(15); put_cnt -= 128; } } // 115200 -> 128 bytes = 11 ms, usb txbuf is small
+    void delay(void) { if (put_cnt > 96) { delay_ms(10); put_cnt = 0; } } // 115200 -> 96 bytes = 8.3 ms, usb txbuf is small
 #endif
 
     void putc(char c) { com->putc(c); if (put_cnt) put_cnt++; delay(); }


### PR DESCRIPTION
To address: https://github.com/olliw42/mLRS/issues/258

Need to stay under ESP32 Tx FIFO buffer of 128, the help command is > 128 and this delay was therefore ineffective.