### PR TITLE
Esp32 RGB LED Library

### DIFF
--- a/mLRS/Common/esp-lib/esp-rgb.h
+++ b/mLRS/Common/esp-lib/esp-rgb.h
@@ -65,6 +65,15 @@ public:
     void Show();
     void ClearTo(RgbColor color, uint16_t first, uint16_t last);
     void SetPixelColor(uint16_t indexPixel, RgbColor color);
+    void redOff(uint16_t first, uint16_t last);
+    void redOn(uint16_t first, uint16_t last);
+    void redToggle(uint16_t first, uint16_t last);
+    void greenOff(uint16_t first, uint16_t last);
+    void greenOn(uint16_t first, uint16_t last);
+    void greenToggle(uint16_t first, uint16_t last);
+    void blueOff(uint16_t first, uint16_t last);
+    void blueOn(uint16_t first, uint16_t last);
+    void blueToggle(uint16_t first, uint16_t last);
 
 private:
     RgbColor *ledsbuff = nullptr;
@@ -72,6 +81,10 @@ private:
     size_t out_buffer_size;
     int num_leds;
     int gpio_pin;
+    bool ledRedState;
+    bool ledGreenState;
+    bool ledBlueState;
+
 };
 
 
@@ -111,7 +124,7 @@ void ESP32LedDriver::Begin()
     i2s_stop(I2S_NUM);
 }
 
-void ESP32LedDriver::Show()
+IRAM_ATTR void ESP32LedDriver::Show()
 {
     size_t bytes_written = 0;
     i2s_stop(I2S_NUM);
@@ -119,7 +132,7 @@ void ESP32LedDriver::Show()
     i2s_start(I2S_NUM);
 }
 
-void ESP32LedDriver::ClearTo(RgbColor color, uint16_t first, uint16_t last)
+IRAM_ATTR void ESP32LedDriver::ClearTo(RgbColor color, uint16_t first, uint16_t last)
 {
     for (uint16_t i=first ; i<=last; i++)
     {
@@ -127,7 +140,7 @@ void ESP32LedDriver::ClearTo(RgbColor color, uint16_t first, uint16_t last)
     }
 }
 
-void ESP32LedDriver::SetPixelColor(uint16_t indexPixel, RgbColor color)
+IRAM_ATTR void ESP32LedDriver::SetPixelColor(uint16_t indexPixel, RgbColor color)
 {
     int loc = indexPixel * 24;
     for(int bitpos = 0 ; bitpos < 8 ; bitpos++)
@@ -137,6 +150,69 @@ void ESP32LedDriver::SetPixelColor(uint16_t indexPixel, RgbColor color)
         out_buffer[loc + bitpos + 8] = (color.R & bit) ? 0xFFE0 : 0xF000;
         out_buffer[loc + bitpos + 16] = (color.B & bit) ? 0xFFE0 : 0xF000;
     }
+}
+
+IRAM_ATTR void ESP32LedDriver::redOff(uint16_t first, uint16_t last)
+{
+    if (!ledRedState) return;
+    ClearTo(RgbColor(0, 0, 0), first, last);
+    Show();
+    ledRedState = 0;
+}
+
+IRAM_ATTR void ESP32LedDriver::redOn(uint16_t first, uint16_t last)
+{
+    if (ledRedState) return;
+    ClearTo(RgbColor(255, 0, 0), first, last);
+    Show();
+    ledRedState = 1;
+}
+
+IRAM_ATTR void ESP32LedDriver::redToggle(uint16_t first, uint16_t last)
+{
+    if (ledRedState) { redOff(first, last); } else { redOn(first, last); }
+}
+
+IRAM_ATTR void ESP32LedDriver::greenOff(uint16_t first, uint16_t last)
+{
+    if (!ledGreenState) return;
+    ClearTo(RgbColor(0, 0, 0), first, last);
+    Show();
+    ledGreenState = 0;
+}
+
+IRAM_ATTR void ESP32LedDriver::greenOn(uint16_t first, uint16_t last)
+{
+    if (ledGreenState) return;
+    ClearTo(RgbColor(0, 255, 0), first, last);
+    Show();
+    ledGreenState = 1;
+}
+
+IRAM_ATTR void ESP32LedDriver::greenToggle(uint16_t first, uint16_t last)
+{
+    if (ledGreenState) { greenOff(first, last); } else { greenOn(first, last); }
+}
+
+IRAM_ATTR void ESP32LedDriver::blueOff(uint16_t first, uint16_t last)
+{
+    if (!ledBlueState) return;
+    ClearTo(RgbColor(0, 0, 0), first, last);
+    Show();
+    ledBlueState = 0;
+}
+
+IRAM_ATTR void ESP32LedDriver::blueOn(uint16_t first, uint16_t last)
+{
+    if (ledBlueState) return;
+    ClearTo(RgbColor(0, 0, 255), first, last);
+    Show();
+    ledBlueState = 1;
+}
+
+IRAM_ATTR void ESP32LedDriver::blueToggle(uint16_t first, uint16_t last)
+{
+    if (ledBlueState) { blueOff(first, last); } else { blueOn(first, last); }
 }
 
 

--- a/mLRS/Common/esp-lib/esp-rgb.h
+++ b/mLRS/Common/esp-lib/esp-rgb.h
@@ -1,0 +1,143 @@
+//*******************************************************
+// Copyright (c) MLRS project
+// GPL3
+// https://www.gnu.org/licenses/gpl-3.0.de.html
+//*******************************************************
+// ESP RGB
+//*******************************************************
+#ifndef ESPLIB_RGB_H
+#define ESPLIB_RGB_H
+
+// RGB led driver that uses I2S peripheral on ESP32, modified and cutdown from ELRS
+
+//-------------------------------------------------------
+// Defines
+//-------------------------------------------------------
+
+#include "driver/i2s.h"
+
+#define I2S_NUM i2s_port_t(0)
+
+#if defined(CONFIG_IDF_TARGET_ESP32S2)
+#define SAMPLE_RATE (360000)
+#define MCLK 48000000
+static const int bitorder[] = {0x40, 0x80, 0x10, 0x20, 0x04, 0x08, 0x01, 0x02};
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+#define SAMPLE_RATE (800000)
+#define MCLK 160000000
+static const int bitorder[] = {0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01};
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+#define SAMPLE_RATE (800000)
+#define MCLK 160000000
+static const int bitorder[] = {0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01};
+#elif defined(CONFIG_IDF_TARGET_ESP32)
+#define SAMPLE_RATE (360000)
+#define MCLK 48000000
+static const int bitorder[] = {0x40, 0x80, 0x10, 0x20, 0x04, 0x08, 0x01, 0x02};
+#endif
+
+
+//-------------------------------------------------------
+//  RgbColor Class
+//-------------------------------------------------------
+
+class RgbColor
+{
+public:
+    RgbColor(uint8_t r, uint8_t g, uint8_t b) : R(r), G(g), B(b) {}
+
+    uint8_t R;
+    uint8_t G;
+    uint8_t B;
+};
+
+
+//-------------------------------------------------------
+//  ESP32LedDriver Class
+//-------------------------------------------------------
+
+class ESP32LedDriver
+{
+public:
+    ESP32LedDriver(int count, int pin);
+
+    void Begin();
+    void Show();
+    void ClearTo(RgbColor color, uint16_t first, uint16_t last);
+    void SetPixelColor(uint16_t indexPixel, RgbColor color);
+
+private:
+    RgbColor *ledsbuff = nullptr;
+    uint16_t *out_buffer = nullptr;
+    size_t out_buffer_size;
+    int num_leds;
+    int gpio_pin;
+};
+
+
+ESP32LedDriver::ESP32LedDriver(int count, int pin) : num_leds(count), gpio_pin(pin)
+{
+    out_buffer_size = num_leds * 24 * sizeof(uint16_t);
+    out_buffer = (uint16_t *)heap_caps_malloc(out_buffer_size, MALLOC_CAP_8BIT);
+}
+
+void ESP32LedDriver::Begin()
+{
+    i2s_config_t i2s_config = {
+        .mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_TX),
+        .sample_rate = SAMPLE_RATE,
+        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
+        .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
+        .communication_format = I2S_COMM_FORMAT_STAND_I2S,
+        .intr_alloc_flags = 0,
+        .dma_buf_count = 4,
+        .use_apll = true,
+        .tx_desc_auto_clear = true,
+        .fixed_mclk = MCLK,
+    };
+
+    i2s_pin_config_t pin_config = {
+        .bck_io_num = -1,
+        .ws_io_num = -1,
+        .data_out_num = gpio_pin,
+        .data_in_num = -1,
+    };
+
+    i2s_config.dma_buf_len = out_buffer_size;
+    i2s_driver_install(I2S_NUM, &i2s_config, 0, NULL);
+    delay(1); // without this it fails to boot and gets stuck!
+    i2s_set_pin(I2S_NUM, &pin_config);
+    i2s_zero_dma_buffer(I2S_NUM);
+    i2s_stop(I2S_NUM);
+}
+
+void ESP32LedDriver::Show()
+{
+    size_t bytes_written = 0;
+    i2s_stop(I2S_NUM);
+    i2s_write(I2S_NUM, out_buffer, out_buffer_size, &bytes_written, portMAX_DELAY);
+    i2s_start(I2S_NUM);
+}
+
+void ESP32LedDriver::ClearTo(RgbColor color, uint16_t first, uint16_t last)
+{
+    for (uint16_t i=first ; i<=last; i++)
+    {
+        SetPixelColor(i, color);
+    }
+}
+
+void ESP32LedDriver::SetPixelColor(uint16_t indexPixel, RgbColor color)
+{
+    int loc = indexPixel * 24;
+    for(int bitpos = 0 ; bitpos < 8 ; bitpos++)
+    {
+        int bit = bitorder[bitpos];
+        out_buffer[loc + bitpos + 0] = (color.G & bit) ? 0xFFE0 : 0xF000;
+        out_buffer[loc + bitpos + 8] = (color.R & bit) ? 0xFFE0 : 0xF000;
+        out_buffer[loc + bitpos + 16] = (color.B & bit) ? 0xFFE0 : 0xF000;
+    }
+}
+
+
+#endif // ESPLIB_RGB_H

--- a/mLRS/Common/esp-lib/esp-rgb.h
+++ b/mLRS/Common/esp-lib/esp-rgb.h
@@ -61,10 +61,10 @@ class ESP32LedDriver
 public:
     ESP32LedDriver(int count, int pin);
 
-    void Begin();
     void Show();
     void ClearTo(RgbColor color, uint16_t first, uint16_t last);
     void SetPixelColor(uint16_t indexPixel, RgbColor color);
+    
     void redOff(uint16_t first, uint16_t last);
     void redOn(uint16_t first, uint16_t last);
     void redToggle(uint16_t first, uint16_t last);
@@ -81,6 +81,7 @@ private:
     size_t out_buffer_size;
     int num_leds;
     int gpio_pin;
+    
     bool ledRedState;
     bool ledGreenState;
     bool ledBlueState;
@@ -92,21 +93,18 @@ ESP32LedDriver::ESP32LedDriver(int count, int pin) : num_leds(count), gpio_pin(p
 {
     out_buffer_size = num_leds * 24 * sizeof(uint16_t);
     out_buffer = (uint16_t *)heap_caps_malloc(out_buffer_size, MALLOC_CAP_8BIT);
-}
 
-void ESP32LedDriver::Begin()
-{
     i2s_config_t i2s_config = {
-        .mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_TX),
-        .sample_rate = SAMPLE_RATE,
-        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
-        .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
-        .communication_format = I2S_COMM_FORMAT_STAND_I2S,
-        .intr_alloc_flags = 0,
-        .dma_buf_count = 4,
-        .use_apll = true,
-        .tx_desc_auto_clear = true,
-        .fixed_mclk = MCLK,
+    .mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_TX),
+    .sample_rate = SAMPLE_RATE,
+    .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
+    .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
+    .communication_format = I2S_COMM_FORMAT_STAND_I2S,
+    .intr_alloc_flags = 0,
+    .dma_buf_count = 4,
+    .use_apll = true,
+    .tx_desc_auto_clear = true,
+    .fixed_mclk = MCLK,
     };
 
     i2s_pin_config_t pin_config = {

--- a/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
@@ -109,68 +109,17 @@ void leds_init(void)
     ledRGB->Begin();
 }
 
-IRAM_ATTR void led_red_off(void)
-{
-    if (!ledRedState) return;
-    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledRedState = 0;
-}
+IRAM_ATTR void led_red_off(void) { ledRGB->redOff(0,0); }
+IRAM_ATTR void led_red_on(void) { ledRGB->redOn(0,0); }
+IRAM_ATTR void led_red_toggle(void) { ledRGB->redToggle(0,0); }
 
-IRAM_ATTR void led_red_on(void)
-{
-    if (ledRedState) return;
-    ledRGB->ClearTo(RgbColor(255, 0, 0), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledRedState = 1;
-}
+IRAM_ATTR void led_green_off(void) { ledRGB->greenOff(0,0); }
+IRAM_ATTR void led_green_on(void) { ledRGB->greenOn(0,0); }
+IRAM_ATTR void led_green_toggle(void) { ledRGB->greenToggle(0,0); }
 
-IRAM_ATTR void led_red_toggle(void)
-{
-    if (ledRedState) { led_red_off(); } else { led_red_on(); }
-}
-
-IRAM_ATTR void led_green_off(void)
-{
-    if (!ledGreenState) return;
-    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledGreenState = 0;
-}
-
-IRAM_ATTR void led_green_on(void)
-{
-    if (ledGreenState) return;
-    ledRGB->ClearTo(RgbColor(0, 255, 0), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledGreenState = 1;
-}
-
-IRAM_ATTR void led_green_toggle(void)
-{
-    if (ledGreenState) { led_green_off(); } else { led_green_on(); }
-}
-
-IRAM_ATTR void led_blue_off(void)
-{
-    if (!ledBlueState) return;
-    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledBlueState = 0;
-}
-
-IRAM_ATTR void led_blue_on(void)
-{
-    if (ledBlueState) return;
-    ledRGB->ClearTo(RgbColor(0, 0, 255), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledBlueState = 1;
-}
-
-IRAM_ATTR void led_blue_toggle(void)
-{
-    if (ledBlueState) { led_blue_off(); } else { led_blue_on(); }
-}
+IRAM_ATTR void led_blue_off(void) { ledRGB->blueOff(0,0); }
+IRAM_ATTR void led_blue_on(void) { ledRGB->blueOn(0,0); }
+IRAM_ATTR void led_blue_toggle(void) { ledRGB->blueToggle(0,0); }
 
 
 //-- POWER

--- a/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
@@ -77,7 +77,7 @@ IRAM_ATTR bool button_pressed(void) { return gpio_read_activelow(BUTTON) ? true 
 
 //-- LEDs
 
-#include "../../esp-lib/esp-rgb.h"  // is there a better way to do this?
+#include "../../esp-lib/esp-rgb.h"
 
 #define LED_PIN                    IO_P8
 #define LED_COUNT                  1

--- a/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
@@ -82,17 +82,9 @@ IRAM_ATTR bool button_pressed(void) { return gpio_read_activelow(BUTTON) ? true 
 #define LED_PIN                    IO_P8
 #define LED_COUNT                  1
 
-bool ledRedState;
-bool ledGreenState;
-bool ledBlueState;
-
 static ESP32LedDriver *ledRGB;
 
-void leds_init(void)
-{
-    ledRGB = new ESP32LedDriver(LED_COUNT, LED_PIN);
-    ledRGB->Begin();
-}
+void leds_init(void) { ledRGB = new ESP32LedDriver(LED_COUNT, LED_PIN); }
 
 IRAM_ATTR void led_red_off(void) { ledRGB->redOff(0,0); }
 IRAM_ATTR void led_red_on(void) { ledRGB->redOn(0,0); }

--- a/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
@@ -53,24 +53,15 @@ void sx_init_gpio(void)
     gpio_init(SX_RESET, IO_MODE_OUTPUT_PP_LOW);
 }
 
-IRAM_ATTR bool sx_busy_read(void)
-{
-    return (gpio_read_activehigh(SX_BUSY)) ? true : false;
-}
+IRAM_ATTR bool sx_busy_read(void) { return (gpio_read_activehigh(SX_BUSY)) ? true : false; }
 
 IRAM_ATTR void sx_amp_transmit(void) {}
 
 IRAM_ATTR void sx_amp_receive(void) {}
 
-void sx_dio_init_exti_isroff(void)
-{
-    detachInterrupt(SX_DIO1);
-}
+void sx_dio_init_exti_isroff(void) { detachInterrupt(SX_DIO1); }
 
-void sx_dio_enable_exti_isr(void)
-{
-    attachInterrupt(SX_DIO1, SX_DIO_EXTI_IRQHandler, RISING);
-}
+void sx_dio_enable_exti_isr(void) { attachInterrupt(SX_DIO1, SX_DIO_EXTI_IRQHandler, RISING); }
 
 IRAM_ATTR void sx_dio_exti_isr_clearflag(void) {}
 
@@ -79,15 +70,9 @@ IRAM_ATTR void sx_dio_exti_isr_clearflag(void) {}
 
 #define BUTTON                    IO_P9
 
-void button_init(void)
-{
-    gpio_init(BUTTON, IO_MODE_INPUT_PU);
-}
+void button_init(void) { gpio_init(BUTTON, IO_MODE_INPUT_PU); }
 
-IRAM_ATTR bool button_pressed(void)
-{
-    return gpio_read_activelow(BUTTON) ? true : false;
-}
+IRAM_ATTR bool button_pressed(void) { return gpio_read_activelow(BUTTON) ? true : false; }
 
 
 //-- LEDs

--- a/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
@@ -91,33 +91,36 @@ IRAM_ATTR bool button_pressed(void)
 
 
 //-- LEDs
-#include <NeoPixelBus.h>
-#define LED_RED                    IO_P8
+#include "../../esp-lib/esp-rgb.h"
+
+#define LED_PIN                    IO_P8
+#define LED_COUNT                  1
+
 bool ledRedState;
 bool ledGreenState;
 bool ledBlueState;
 
-NeoPixelBus<NeoGrbFeature, NeoEsp32Rmt0Ws2812xMethod> ledRGB(1, LED_RED);
+static ESP32LedDriver *ledRGB;
 
 void leds_init(void)
 {
-    ledRGB.Begin();
-    ledRGB.Show();
+    ledRGB = new ESP32LedDriver(LED_COUNT, LED_PIN);
+    ledRGB->Begin();
 }
 
 IRAM_ATTR void led_red_off(void)
 {
     if (!ledRedState) return;
-    ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledRedState = 0;
 }
 
 IRAM_ATTR void led_red_on(void)
 {
     if (ledRedState) return;
-    ledRGB.SetPixelColor(0, RgbColor(255, 0, 0));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(255, 0, 0), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledRedState = 1;
 }
 
@@ -129,16 +132,16 @@ IRAM_ATTR void led_red_toggle(void)
 IRAM_ATTR void led_green_off(void)
 {
     if (!ledGreenState) return;
-    ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledGreenState = 0;
 }
 
 IRAM_ATTR void led_green_on(void)
 {
     if (ledGreenState) return;
-    ledRGB.SetPixelColor(0, RgbColor(0, 255, 0));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(0, 255, 0), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledGreenState = 1;
 }
 
@@ -150,16 +153,16 @@ IRAM_ATTR void led_green_toggle(void)
 IRAM_ATTR void led_blue_off(void)
 {
     if (!ledBlueState) return;
-    ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledBlueState = 0;
 }
 
 IRAM_ATTR void led_blue_on(void)
 {
     if (ledBlueState) return;
-    ledRGB.SetPixelColor(0, RgbColor(0, 0, 255));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(0, 0, 255), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledBlueState = 1;
 }
 

--- a/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-c3-lr1121-esp32c3.h
@@ -91,7 +91,8 @@ IRAM_ATTR bool button_pressed(void)
 
 
 //-- LEDs
-#include "../../esp-lib/esp-rgb.h"
+
+#include "../../esp-lib/esp-rgb.h"  // is there a better way to do this?
 
 #define LED_PIN                    IO_P8
 #define LED_COUNT                  1

--- a/mLRS/Common/hal/esp/rx-hal-generic-lr1121-td-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-lr1121-td-esp32.h
@@ -52,24 +52,15 @@ void sx_init_gpio(void)
     gpio_init(SX_RESET, IO_MODE_OUTPUT_PP_LOW);
 }
 
-IRAM_ATTR bool sx_busy_read(void)
-{
-    return (gpio_read_activehigh(SX_BUSY)) ? true : false;
-}
+IRAM_ATTR bool sx_busy_read(void) { return (gpio_read_activehigh(SX_BUSY)) ? true : false; }
 
 IRAM_ATTR void sx_amp_transmit(void) {}
 
 IRAM_ATTR void sx_amp_receive(void) {}
 
-void sx_dio_init_exti_isroff(void)
-{
-    detachInterrupt(SX_DIO1);
-}
+void sx_dio_init_exti_isroff(void) { detachInterrupt(SX_DIO1); }
 
-void sx_dio_enable_exti_isr(void)
-{
-    attachInterrupt(SX_DIO1, SX_DIO_EXTI_IRQHandler, RISING);
-}
+void sx_dio_enable_exti_isr(void) { attachInterrupt(SX_DIO1, SX_DIO_EXTI_IRQHandler, RISING); }
 
 IRAM_ATTR void sx_dio_exti_isr_clearflag(void) {}
 
@@ -93,34 +84,19 @@ void sx2_init_gpio(void)
     gpio_init(SX2_RESET, IO_MODE_OUTPUT_PP_LOW);
 }
 
-IRAM_ATTR void spib_select(void)
-{
-    gpio_low(SX2_CS_IO);
-}
+IRAM_ATTR void spib_select(void) {  gpio_low(SX2_CS_IO); }
 
-IRAM_ATTR void spib_deselect(void)
-{
-    gpio_high(SX2_CS_IO);
-}
+IRAM_ATTR void spib_deselect(void) { gpio_high(SX2_CS_IO); }
 
-IRAM_ATTR bool sx2_busy_read(void)
-{
-    return (gpio_read_activehigh(SX2_BUSY)) ? true : false;
-}
+IRAM_ATTR bool sx2_busy_read(void) { return (gpio_read_activehigh(SX2_BUSY)) ? true : false; }
 
 IRAM_ATTR void sx2_amp_transmit(void) {}
 
 IRAM_ATTR void sx2_amp_receive(void) {}
 
-void sx2_dio_init_exti_isroff(void)
-{
-    detachInterrupt(SX2_DIO1);
-}
+void sx2_dio_init_exti_isroff(void) { detachInterrupt(SX2_DIO1); }
 
-void sx2_dio_enable_exti_isr(void)
-{
-    attachInterrupt(SX2_DIO1, SX2_DIO_EXTI_IRQHandler, RISING);
-}
+void sx2_dio_enable_exti_isr(void) { attachInterrupt(SX2_DIO1, SX2_DIO_EXTI_IRQHandler, RISING); }
 
 void sx2_dio_exti_isr_clearflag(void) {}
 
@@ -129,98 +105,33 @@ void sx2_dio_exti_isr_clearflag(void) {}
 
 #define BUTTON                    IO_P0
 
-void button_init(void)
-{
-    gpio_init(BUTTON, IO_MODE_INPUT_PU);
-}
+void button_init(void) { gpio_init(BUTTON, IO_MODE_INPUT_PU); }
 
-IRAM_ATTR bool button_pressed(void)
-{
-    return gpio_read_activelow(BUTTON) ? true : false;
-}
+IRAM_ATTR bool button_pressed(void) { return gpio_read_activelow(BUTTON) ? true : false; }
 
 
 //-- LEDs
 
-#include "../../esp-lib/esp-rgb.h"  // is there a better way to do this?
+#include "../../esp-lib/esp-rgb.h"
 
 #define LED_PIN                    IO_P22
 #define LED_COUNT                  1
 
-bool ledRedState;
-bool ledGreenState;
-bool ledBlueState;
-
 static ESP32LedDriver *ledRGB;
 
-void leds_init(void)
-{
-    ledRGB = new ESP32LedDriver(LED_COUNT, LED_PIN);
-    ledRGB->Begin();
-}
+void leds_init(void) { ledRGB = new ESP32LedDriver(LED_COUNT, LED_PIN); }
 
-IRAM_ATTR void led_red_off(void)
-{
-    if (!ledRedState) return;
-    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledRedState = 0;
-}
+IRAM_ATTR void led_red_off(void) { ledRGB->redOff(0,0); }
+IRAM_ATTR void led_red_on(void) { ledRGB->redOn(0,0); }
+IRAM_ATTR void led_red_toggle(void) { ledRGB->redToggle(0,0); }
 
-IRAM_ATTR void led_red_on(void)
-{
-    if (ledRedState) return;
-    ledRGB->ClearTo(RgbColor(255, 0, 0), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledRedState = 1;
-}
+IRAM_ATTR void led_green_off(void) { ledRGB->greenOff(0,0); }
+IRAM_ATTR void led_green_on(void) { ledRGB->greenOn(0,0); }
+IRAM_ATTR void led_green_toggle(void) { ledRGB->greenToggle(0,0); }
 
-IRAM_ATTR void led_red_toggle(void)
-{
-    if (ledRedState) { led_red_off(); } else { led_red_on(); }
-}
-
-IRAM_ATTR void led_green_off(void)
-{
-    if (!ledGreenState) return;
-    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledGreenState = 0;
-}
-
-IRAM_ATTR void led_green_on(void)
-{
-    if (ledGreenState) return;
-    ledRGB->ClearTo(RgbColor(0, 255, 0), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledGreenState = 1;
-}
-
-IRAM_ATTR void led_green_toggle(void)
-{
-    if (ledGreenState) { led_green_off(); } else { led_green_on(); }
-}
-
-IRAM_ATTR void led_blue_off(void)
-{
-    if (!ledBlueState) return;
-    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledBlueState = 0;
-}
-
-IRAM_ATTR void led_blue_on(void)
-{
-    if (ledBlueState) return;
-    ledRGB->ClearTo(RgbColor(0, 0, 255), 0, LED_COUNT - 1);
-    ledRGB->Show();
-    ledBlueState = 1;
-}
-
-IRAM_ATTR void led_blue_toggle(void)
-{
-    if (ledBlueState) { led_blue_off(); } else { led_blue_on(); }
-}
+IRAM_ATTR void led_blue_off(void) { ledRGB->blueOff(0,0); }
+IRAM_ATTR void led_blue_on(void) { ledRGB->blueOn(0,0); }
+IRAM_ATTR void led_blue_toggle(void) { ledRGB->blueToggle(0,0); }
 
 
 //-- POWER

--- a/mLRS/Common/hal/esp/rx-hal-generic-lr1121-td-esp32.h
+++ b/mLRS/Common/hal/esp/rx-hal-generic-lr1121-td-esp32.h
@@ -141,33 +141,37 @@ IRAM_ATTR bool button_pressed(void)
 
 
 //-- LEDs
-#include <NeoPixelBus.h>
-#define LED_RED                    IO_P22
+
+#include "../../esp-lib/esp-rgb.h"  // is there a better way to do this?
+
+#define LED_PIN                    IO_P22
+#define LED_COUNT                  1
+
 bool ledRedState;
 bool ledGreenState;
 bool ledBlueState;
 
-NeoPixelBus<NeoGrbFeature, NeoEsp32I2s0Ws2812xMethod> ledRGB(1, LED_RED);
+static ESP32LedDriver *ledRGB;
 
 void leds_init(void)
 {
-    ledRGB.Begin();
-    ledRGB.Show();
+    ledRGB = new ESP32LedDriver(LED_COUNT, LED_PIN);
+    ledRGB->Begin();
 }
 
 IRAM_ATTR void led_red_off(void)
 {
     if (!ledRedState) return;
-    ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledRedState = 0;
 }
 
 IRAM_ATTR void led_red_on(void)
 {
     if (ledRedState) return;
-    ledRGB.SetPixelColor(0, RgbColor(255, 0, 0));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(255, 0, 0), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledRedState = 1;
 }
 
@@ -179,16 +183,16 @@ IRAM_ATTR void led_red_toggle(void)
 IRAM_ATTR void led_green_off(void)
 {
     if (!ledGreenState) return;
-    ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledGreenState = 0;
 }
 
 IRAM_ATTR void led_green_on(void)
 {
     if (ledGreenState) return;
-    ledRGB.SetPixelColor(0, RgbColor(0, 255, 0));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(0, 255, 0), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledGreenState = 1;
 }
 
@@ -200,16 +204,16 @@ IRAM_ATTR void led_green_toggle(void)
 IRAM_ATTR void led_blue_off(void)
 {
     if (!ledBlueState) return;
-    ledRGB.SetPixelColor(0, RgbColor(0, 0, 0));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(0, 0, 0), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledBlueState = 0;
 }
 
 IRAM_ATTR void led_blue_on(void)
 {
     if (ledBlueState) return;
-    ledRGB.SetPixelColor(0, RgbColor(0, 0, 255));
-    ledRGB.Show();
+    ledRGB->ClearTo(RgbColor(0, 0, 255), 0, LED_COUNT - 1);
+    ledRGB->Show();
     ledBlueState = 1;
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -158,8 +158,6 @@ build_flags =
 [env:rx-generic-lr1121-td]
 extends = env_common_rx_esp32c3
 board = pico32
-lib_deps =
-  makuna/NeoPixelBus@^2.8.3
 build_src_filter =
   ${env_common_rx_esp32.build_src_filter}
   +<modules/sx12xx-lib/src/lr11xx.cpp>
@@ -171,8 +169,6 @@ build_flags =
 [env:rx-generic-c3-lr1121]
 extends = env_common_rx_esp32c3
 board = esp32-c3-devkitm-1
-lib_deps =
-  ; makuna/NeoPixelBus@^2.8.3
 build_src_filter =
   ${env_common_rx_esp32c3.build_src_filter}
   +<modules/sx12xx-lib/src/lr11xx.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -172,7 +172,7 @@ build_flags =
 extends = env_common_rx_esp32c3
 board = esp32-c3-devkitm-1
 lib_deps =
-  makuna/NeoPixelBus@^2.8.3
+  ; makuna/NeoPixelBus@^2.8.3
 build_src_filter =
   ${env_common_rx_esp32c3.build_src_filter}
   +<modules/sx12xx-lib/src/lr11xx.cpp>


### PR DESCRIPTION
To replace Neopixelbus library, primary motivations:

- Neopixelbus only allows one to use the RMT peripheral on ESP32C3, using I2S peripheral should generate fewer interrupts.
- Allows more flexibility as uses ESP-IDF I2S driver.

Tested working on:
- Plain ESP32 (Radiomaster DBR4) 
- ESP32C3 (Radiomaster XR1)
- ESP32S3 (Devboard)