### PR TITLE
Bridge esp32 c3 ifdef

### DIFF
--- a/esp/mlrs-wireless-bridge/mlrs-wireless-bridge.ino
+++ b/esp/mlrs-wireless-bridge/mlrs-wireless-bridge.ino
@@ -151,16 +151,14 @@ String bluetooth_device_name = ""; // "mLRS BT"; // Bluetooth device name, "" re
 //-------------------------------------------------------
 
 #if CONFIG_IDF_TARGET_ESP32C3
-#if ESP_ARDUINO_VERSION != ESP_ARDUINO_VERSION_VAL(2, 0, 17)
+  #if ESP_ARDUINO_VERSION != ESP_ARDUINO_VERSION_VAL(2, 0, 17)
     #error ESP32C3 requires ESP Arduino Core 2.0.17 !
-#endif
-#else
-#if ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+  #endif
+#elif ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 0, 0)
     #error Version of your ESP Arduino Core below 3.0.0 !
 #elif ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 0, 4)
     #warning Consider upgrading your ESP Arduino Core ! // warnings may not be displayed in console !
 #endif
-#endif  // CONFIG_IDF_TARGET_ESP32C3
 
 #ifdef GPIO0_IO
 #define USE_AT_MODE

--- a/esp/mlrs-wireless-bridge/mlrs-wireless-bridge.ino
+++ b/esp/mlrs-wireless-bridge/mlrs-wireless-bridge.ino
@@ -58,7 +58,7 @@ Troubleshooting:
 //#define MODULE_M5STAMP_PICO
 //#define MODULE_M5STAMP_PICO_FOR_FRSKY_R9M // uses inverted serial
 //#define MODULE_M5STACK_ATOM_LITE
-//#define MODULE_GENERIC
+#define MODULE_GENERIC
 //#define MODULE_DIY_E28DUAL_MODULE02_G491RE
 
 // Serial level
@@ -73,7 +73,7 @@ Troubleshooting:
 
 // GPIO0 usage
 // uncomment, if your Tx module does support the RESET and GPIO0 lines on the EPS32 (aka AT mode)
-// the number determines the IO pin, usally it is 0
+// the number determines the IO pin, usually it is 0.  On ESP32C3 it is 9.
 //#define GPIO0_IO  0
 
 
@@ -150,11 +150,17 @@ String bluetooth_device_name = ""; // "mLRS BT"; // Bluetooth device name, "" re
 // Includes
 //-------------------------------------------------------
 
+#if CONFIG_IDF_TARGET_ESP32C3
+#if ESP_ARDUINO_VERSION != ESP_ARDUINO_VERSION_VAL(2, 0, 17)
+    #error ESP32C3 requires ESP Arduino Core 2.0.17 !
+#endif
+#else
 #if ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 0, 0)
     #error Version of your ESP Arduino Core below 3.0.0 !
 #elif ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 0, 4)
     #warning Consider upgrading your ESP Arduino Core ! // warnings may not be displayed in console !
 #endif
+#endif  // CONFIG_IDF_TARGET_ESP32C3
 
 #ifdef GPIO0_IO
 #define USE_AT_MODE

--- a/esp/mlrs-wireless-bridge/mlrs-wireless-bridge.ino
+++ b/esp/mlrs-wireless-bridge/mlrs-wireless-bridge.ino
@@ -58,7 +58,7 @@ Troubleshooting:
 //#define MODULE_M5STAMP_PICO
 //#define MODULE_M5STAMP_PICO_FOR_FRSKY_R9M // uses inverted serial
 //#define MODULE_M5STACK_ATOM_LITE
-#define MODULE_GENERIC
+//#define MODULE_GENERIC
 //#define MODULE_DIY_E28DUAL_MODULE02_G491RE
 
 // Serial level


### PR DESCRIPTION
Bridge on ESP32C3 requires core 2.0.17 otherwise the WiFi name and channel aren't able to be set correctly.