### PR TITLE
LR11xx No FSK

### DIFF
--- a/mLRS/Common/setup.h
+++ b/mLRS/Common/setup.h
@@ -86,7 +86,7 @@ void setup_configure_metadata(void)
 #elif defined DEVICE_HAS_SX127x
     SetupMetaData.Mode_allowed_mask = 0b00100; // 19 Hz, not editable
 #elif defined DEVICE_HAS_LR11xx
-    SetupMetaData.Mode_allowed_mask = 0b10110; // 31 Hz, 19 Hz, FSK
+    SetupMetaData.Mode_allowed_mask = 0b00110; // 31 Hz, 19 Hz, No FSK
 #endif
 
     //-- Ortho: "off,1/3,2/3,3/3"


### PR DESCRIPTION
FSK on diversity hardware (DBR4, XR4) showed link drops with Matek mR900 Tx, so restricting to 19 and 31 Hz.