### PR TITLE
LR, no extra IRQ calls

### DIFF
--- a/mLRS/Common/sx-drivers/lr11xx_driver.h
+++ b/mLRS/Common/sx-drivers/lr11xx_driver.h
@@ -214,7 +214,6 @@ class Lr11xxDriverCommon : public Lr11xxDriverBase
         SetPaConfig(LR11XX_PA_SELECT_LP_PA, LR11XX_REG_PA_SUPPLY_INTERNAL, LR11XX_PA_DUTY_CYCLE_14_DBM, 0);
 #endif
         SetRfPower_dbm(gconfig->Power_dbm);
-        ClearIrq(LR11XX_IRQ_ALL);
         SetFs();
     }
 
@@ -232,20 +231,17 @@ class Lr11xxDriverCommon : public Lr11xxDriverBase
     void SendFrame(uint8_t* const data, uint8_t len, uint16_t tmo_ms)
     {
         WriteBuffer(data, len);
-        ClearIrq(LR11XX_IRQ_ALL);
         SetTx(tmo_ms * 33); // 0 = no timeout. TimeOut period in ms. LR11xx have static 30.517 uS (1 / 32768) period base, so for 1 ms needs 33 tmo value
     }
 
     void SetToRx(uint16_t tmo_ms)
     {
-        ClearIrq(LR11XX_IRQ_ALL);
         SetRx(tmo_ms * 33); // 0 = no timeout
     }
 
     void SetToIdle(void)
     {
         SetFs();
-        ClearIrq(LR11XX_IRQ_ALL);
     }
 
     void GetPacketStatus(int8_t* const RssiSync, int8_t* const Snr)


### PR DESCRIPTION
To reduce commands sent to LR chipset.

Anytime that there is an IRQ raised, it is immediately cleared in the ISR.  These calls are therefore not needed.  Could also be applied to other chipsets.

Tested for a few hours on the bench.