### PR TITLE
Fewer Sx Calls

### DIFF
--- a/mLRS/Common/common.h
+++ b/mLRS/Common/common.h
@@ -233,9 +233,9 @@ tLEDs leds;
 void sxReadFrame(uint8_t antenna, void* const data, void* const data2, uint8_t len)
 {
     if (antenna == ANTENNA_1) {
-        sx.ReadFrame((uint8_t*)data, len);
+        sx.ReadBuffer(0, (uint8_t*)data, len);
     } else {
-        sx2.ReadFrame((uint8_t*)data2, len);
+        sx2.ReadBuffer(0, (uint8_t*)data2, len);
     }
 }
 
@@ -245,10 +245,8 @@ void sxSendFrame(uint8_t antenna, void* const data, uint8_t len, uint16_t tmo_ms
 #if !defined DEVICE_HAS_DUAL_SX126x_SX128x && !defined DEVICE_HAS_DUAL_SX126x_SX126x // SINGLE BAND
     if (antenna == ANTENNA_1) {
         sx.SendFrame((uint8_t*)data, len, tmo_ms);
-        sx2.SetToIdle();
     } else {
         sx2.SendFrame((uint8_t*)data, len, tmo_ms);
-        sx.SetToIdle();
     }
 #else
     sx.SendFrame((uint8_t*)data, len, tmo_ms);

--- a/mLRS/Common/sx-drivers/sx12xx_driver.h
+++ b/mLRS/Common/sx-drivers/sx12xx_driver.h
@@ -127,6 +127,7 @@ class SxDriverDummy
     void GetPacketStatus(int8_t* const RssiSync, int8_t* const Snr) {}
     void SendFrame(uint8_t* const data, uint8_t len, uint16_t tmo_ms) {}
     void ReadFrame(uint8_t* const data, uint8_t len) {}
+    void ReadBuffer(uint8_t offset, uint8_t* const data, uint8_t len) {}
     void SetToRx(uint16_t tmo_ms) {}
     void SetToIdle(void) {}
 


### PR DESCRIPTION
Remove a few unnecessary Sx calls:

- ReadBuffer used instead of ReadFrame to avoid the call to GetRxBufferStatus, same thing done in ISR: https://github.com/olliw42/mLRS/blob/main/mLRS/CommonTx/mlrs-tx.cpp#L322
- Sx that is not transmitting is already in idle before a transmit, for the Tx side this is done in doPreTransmit: https://github.com/olliw42/mLRS/blob/main/mLRS/CommonTx/mlrs-tx.cpp#L945-L946 and for the Rx side this is done in doPostReceive: https://github.com/olliw42/mLRS/blob/main/mLRS/CommonRx/mlrs-rx.cpp#L839-L840