### PR TITLE
ESP32 Rx Clock on Core 0

### DIFF
--- a/mLRS/Common/hal/esp-rxclock.h
+++ b/mLRS/Common/hal/esp-rxclock.h
@@ -15,8 +15,9 @@
 // but with the interrupt on the other core need to make sure all shared resources are protected
 // to make things a little simpler, keep the 1 ms uWtick timer interrupt on core 1 (this has 100x less overhead, so ok)
 // the following variables are shared across cores (used in the isr on core 0) and need to be protected with spinlocks:
-//     CNT_10us, CCR1, CCR3, CLOCK_PERIOD_10US, doPostReceiveESP32
+//     CNT_10us, CCR1, CCR3, CLOCK_PERIOD_10US
 // CLOCK_SHIFT_10US is a define, so not included
+// doPostReceive is only potentially read / write by either Core at the same time, so okay to not use spinlock
 
 
 #define CLOCK_SHIFT_10US          100 // 75 // 100 // 1 ms

--- a/mLRS/Common/hal/esp-rxclock.h
+++ b/mLRS/Common/hal/esp-rxclock.h
@@ -9,6 +9,15 @@
 #define ESP_RXCLOCK_H
 #pragma once
 
+// interrupts on ESP32 are slow (~2 us) so having a 10 us / 100 kHz timer interrupt generates a lot of overhead
+// 2 us * 100 kHz = 200000 us = 200 ms, every second !!!
+// the arduino task (which is used by mLRS) runs on core 1, so move the interrupt to core 0
+// but with the interrupt on the other core need to make sure all shared resources are protected
+// to make things a little simpler, keep the 1 ms uWtick timer interrupt on core 1 (this has 100x less overhead, so ok)
+// the following variables are shared across cores (used in the isr on core 0) and need to be protected with spinlocks:
+//     CNT_10us, CCR1, CCR3, CLOCK_PERIOD_10US, doPostReceiveESP32
+// CLOCK_SHIFT_10US is a define, so not included
+
 
 #define CLOCK_SHIFT_10US          100 // 75 // 100 // 1 ms
 #define CLOCK_CNT_1MS             100 // 10us interval 10us x 100 = 1000us
@@ -19,7 +28,8 @@
 #endif
 
 
-volatile bool doPostReceive;
+volatile bool doPostReceive = false;
+volatile bool doPostReceiveESP32 = false;
 
 uint16_t CLOCK_PERIOD_10US; // does not change while isr is enabled, so no need for volatile
 
@@ -33,13 +43,37 @@ volatile uint32_t MS_C = CLOCK_CNT_1MS;
 // Clock ISR
 //-------------------------------------------------------
 
+#ifdef ESP32
+IRQHANDLER(
+void CLOCK1MS_IRQHandler(void)
+{
+    HAL_IncTick();
+})
+    
+IRQHANDLER(
+void CLOCK10US_IRQHandler(void)
+{
+    taskENTER_CRITICAL_ISR(&esp32_spinlock);
+
+    CNT_10us++;
+
+    // this is at about when RX was or was supposed to be received
+    if (CNT_10us == CCR1) {
+        CCR3 = CNT_10us + CLOCK_SHIFT_10US; // next doPostReceive
+        CCR1 = CNT_10us + CLOCK_PERIOD_10US; // next tick
+    }
+
+    // this is 1 ms after RX was or was supposed to be received
+    if (CNT_10us == CCR3) {
+        doPostReceiveESP32 = true;
+    }
+
+    taskEXIT_CRITICAL_ISR(&esp32_spinlock);
+})
+#elif defined ESP8266
 IRQHANDLER(
 void CLOCK_IRQHandler(void)
 {
-#ifdef ESP32
-    taskENTER_CRITICAL_ISR(&esp32_spinlock);
-#endif
-
     CNT_10us++;
 
     // call HAL_IncTick every 1 ms
@@ -59,10 +93,8 @@ void CLOCK_IRQHandler(void)
         doPostReceive = true;
     }
 
-#ifdef ESP32
-    taskEXIT_CRITICAL_ISR(&esp32_spinlock);
-#endif
 })
+#endif
 
 
 //-------------------------------------------------------
@@ -84,7 +116,6 @@ class tRxClock
 void tRxClock::Init(uint16_t period_ms)
 {
     CLOCK_PERIOD_10US = period_ms * 100; // frame rate in units of 10us
-    doPostReceive = false;
 
     CNT_10us = 0;
     CCR1 = CLOCK_PERIOD_10US;
@@ -93,25 +124,24 @@ void tRxClock::Init(uint16_t period_ms)
 
     if (initialized) return;
 
-    // initialize the timer
+    // initialize the timer(s)
 #ifdef ESP32
-    xTaskCreatePinnedToCore([](void *parameter)
-    {
-        hw_timer_t* timer0_cfg = nullptr;
-        timer0_cfg = timerBegin(0, 800, 1);  // Timer 0, APB clock is 80 Mhz | divide by 800 is 100 KHz / 10 us, count up
-        timerAttachInterrupt(timer0_cfg, &CLOCK_IRQHandler, true);
-        timerAlarmWrite(timer0_cfg, 1, true);
-        timerAlarmEnable(timer0_cfg);
+    // initialize the 1 ms uwTick timer
+    hw_timer_t* timer0_cfg = nullptr;
+    timer0_cfg = timerBegin(0, 800, 1);  // Timer 0, APB clock is 80 Mhz | divide by 800 is 100 KHz / 10 us, count up
+    timerAttachInterrupt(timer0_cfg, &CLOCK1MS_IRQHandler, true);
+    timerAlarmWrite(timer0_cfg, 100, true); // 10 us * 100 = 1 ms
+    timerAlarmEnable(timer0_cfg);
 
+    // initialize the 10 us doPostReceive timer, put it on Core 0
+    xTaskCreatePinnedToCore([](void *parameter) {
+        hw_timer_t* timer1_cfg = nullptr;
+        timer1_cfg = timerBegin(1, 800, 1);  // Timer 1, APB clock is 80 Mhz | divide by 800 is 100 KHz / 10 us, count up
+        timerAttachInterrupt(timer1_cfg, &CLOCK10US_IRQHandler, true);
+        timerAlarmWrite(timer1_cfg, 1, true);
+        timerAlarmEnable(timer1_cfg);
         vTaskDelete(NULL);
-    },
-        "TimerSetup",  // Task name
-        2048,          // Stack size
-        NULL,          // Parameters
-        1,             // Priority
-        NULL,          // Task handle
-        0              // Core ID, 1 is used by Arduino.  Ignored on ESP32C3
-    );
+    }, "TimerSetup", 2048, NULL, 1, NULL, 0);  // last argument here is Core 0, ignored on ESP32C3
 #elif defined ESP8266
     timer1_attachInterrupt(CLOCK_IRQHandler);
     timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);
@@ -123,7 +153,13 @@ void tRxClock::Init(uint16_t period_ms)
 
 IRAM_ATTR void tRxClock::SetPeriod(uint16_t period_ms)
 {
+#ifdef ESP32
+    taskENTER_CRITICAL(&esp32_spinlock);
+#endif
     CLOCK_PERIOD_10US = period_ms * 100;
+#ifdef ESP32
+    taskEXIT_CRITICAL(&esp32_spinlock);
+#endif
 }
 
 
@@ -138,10 +174,10 @@ IRAM_ATTR void tRxClock::Reset(void)
 #endif
     CCR1 = CNT_10us + CLOCK_PERIOD_10US;
     CCR3 = CNT_10us + CLOCK_SHIFT_10US;
-    MS_C = CNT_10us + CLOCK_CNT_1MS;
 #ifdef ESP32
     taskEXIT_CRITICAL(&esp32_spinlock);
 #elif defined ESP8266
+    MS_C = CNT_10us + CLOCK_CNT_1MS;  // MS_C only used on ESP8266
     interrupts();
 #endif
 }

--- a/mLRS/Common/hal/esp-rxclock.h
+++ b/mLRS/Common/hal/esp-rxclock.h
@@ -36,6 +36,10 @@ volatile uint32_t MS_C = CLOCK_CNT_1MS;
 IRQHANDLER(
 void CLOCK_IRQHandler(void)
 {
+#ifdef ESP32
+    taskENTER_CRITICAL_ISR(&esp32_spinlock);
+#endif
+
     CNT_10us++;
 
     // call HAL_IncTick every 1 ms
@@ -55,6 +59,9 @@ void CLOCK_IRQHandler(void)
         doPostReceive = true;
     }
 
+#ifdef ESP32
+    taskEXIT_CRITICAL_ISR(&esp32_spinlock);
+#endif
 })
 
 

--- a/mLRS/CommonRx/mlrs-rx.cpp
+++ b/mLRS/CommonRx/mlrs-rx.cpp
@@ -723,15 +723,6 @@ IF_SX2(
     }//end of if(irq2_status)
 );
 
-#ifdef ESP32
-    taskENTER_CRITICAL(&esp32_spinlock);
-    if (doPostReceiveESP32) { 
-        doPostReceiveESP32 = false;
-        doPostReceive = true; 
-    }
-    taskEXIT_CRITICAL(&esp32_spinlock);
-#endif
-
     // this happens ca 1 ms after a frame was or should have been received
     if (doPostReceive) {
         doPostReceive = false;

--- a/mLRS/CommonRx/mlrs-rx.cpp
+++ b/mLRS/CommonRx/mlrs-rx.cpp
@@ -723,6 +723,15 @@ IF_SX2(
     }//end of if(irq2_status)
 );
 
+#ifdef ESP32
+    taskENTER_CRITICAL(&esp32_spinlock);
+    if (doPostReceiveESP32) { 
+        doPostReceiveESP32 = false;
+        doPostReceive = true; 
+    }
+    taskEXIT_CRITICAL(&esp32_spinlock);
+#endif
+
     // this happens ca 1 ms after a frame was or should have been received
     if (doPostReceive) {
         doPostReceive = false;


### PR DESCRIPTION
Interrupts on ESP32 take something like 1-2 us, so a 10 us interrupt (100 KHz) means something like 100-200ms per second was being used to service this interrupt.

Previously FSK on DBR4 / XR4 would show bad link drops when running 115200 baud.  Now the LQ is rock solid at 100% when running FSK with 230400 baud.  ESP32C3 can use the same code even though it is single core.

Tested on:
- RadioMaster XR4
- RadioMaster XR1
- BetaFPV SuperD