### PR TITLE
fix lr1121 td extend

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -156,7 +156,7 @@ build_flags =
 
 
 [env:rx-generic-lr1121-td]
-extends = env_common_rx_esp32c3
+extends = env_common_rx_esp32
 board = pico32
 lib_deps =
   makuna/NeoPixelBus@^2.8.3


### PR DESCRIPTION
LR1121 TD is an ESP32 _not_ ESP32C3