### PR TITLE
PIO Tidy

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -144,7 +144,7 @@ build_flags =
 
 [env:rx-generic-900-td-pa]
 extends = env_common_rx_esp32
-board = pico32
+board = esp32dev
 lib_deps =
   makuna/NeoPixelBus@^2.8.3
 build_src_filter =
@@ -157,7 +157,7 @@ build_flags =
 
 [env:rx-generic-lr1121-td]
 extends = env_common_rx_esp32
-board = pico32
+board = esp32dev
 lib_deps =
   makuna/NeoPixelBus@^2.8.3
 build_src_filter =
@@ -237,7 +237,7 @@ build_flags =
 
 [env:rx-generic-2400-td-pa]
 extends = env_common_rx_esp32
-board = pico32
+board = esp32dev
 lib_deps =
   makuna/NeoPixelBus@^2.8.3
 build_src_filter =
@@ -312,11 +312,11 @@ build_flags =
   -D RX_ELRS_RADIOMASTER_XR1_900_ESP32C3
 
 
-;-- some ELRS Tx External Modules; ONLY FOR SIK TELEMETRY!
+;-- some ELRS Tx External Modules
 
 [env:tx-radiomaster-rp4td-2400-sik-telem]
 extends = env_common_tx_esp32
-board = pico32
+board = esp32dev
 lib_deps =
   makuna/NeoPixelBus@^2.8.3
 build_src_filter =


### PR DESCRIPTION
- pico32 and esp32dev are essentially the same define just named differently, so just have one.
- remove out of date comment

esp32dev json: https://github.com/platformio/platform-espressif32/blob/develop/boards/esp32dev.json
pico32 json: https://github.com/platformio/platform-espressif32/blob/develop/boards/pico32.json