### PR TITLE
Add addresses to CRSF device info

### DIFF
--- a/mLRS/CommonTx/crsf_interface_tx.h
+++ b/mLRS/CommonTx/crsf_interface_tx.h
@@ -1000,10 +1000,15 @@ tCrsfLinkStatisticsRx clstats;
 
 void tTxCrsf::SendDeviceInfo(void)
 {
+// extended frame, so need to send the destination and origin addresses
+
 char buf[64];
 
-    strcpy(buf, "MLRS " DEVICE_NAME " " VERSIONONLYSTR);
-    uint8_t name_len = strlen(buf);
+    buf[0] = 0x00;  // destination address, 0x00 = broadcast
+    buf[1] = 0xEE;  // origin address, 0xEE = module, EdgeTx looks for this
+
+    strcpy(buf + 2, "MLRS " DEVICE_NAME);  // device name + versiononlystr too long
+    uint8_t name_len = strlen(buf + 2);
 
     tCrsfDeviceInfoFragment* dvif_ptr = (tCrsfDeviceInfoFragment*)(buf + name_len + 1);
     dvif_ptr->serial_number = 12345; // TODO

--- a/mLRS/CommonTx/crsf_interface_tx.h
+++ b/mLRS/CommonTx/crsf_interface_tx.h
@@ -1010,14 +1010,14 @@ char buf[64];
     strcpy(buf + 2, "MLRS " DEVICE_NAME " " VERSIONONLYSTR);
     uint8_t name_len = strlen(buf + 2);
 
-    tCrsfDeviceInfoFragment* dvif_ptr = (tCrsfDeviceInfoFragment*)(buf + name_len + 1);
+    tCrsfDeviceInfoFragment* dvif_ptr = (tCrsfDeviceInfoFragment*)(buf + 2 + name_len + 1);
     dvif_ptr->serial_number = 12345; // TODO
     dvif_ptr->hardware_id = 54321; // TODO
     dvif_ptr->firmware_id = VERSION;
     dvif_ptr->parameters_total = 0;
     dvif_ptr->parameter_version_number = 0;
 
-    send_frame(CRSF_FRAME_ID_DEVICE_INFO, buf, name_len + 1 + CRSF_DEVICE_INFO_FRAGMENT_LEN);
+    send_frame(CRSF_FRAME_ID_DEVICE_INFO, buf, 2 + name_len + 1 + CRSF_DEVICE_INFO_FRAGMENT_LEN);
 }
 
 

--- a/mLRS/CommonTx/crsf_interface_tx.h
+++ b/mLRS/CommonTx/crsf_interface_tx.h
@@ -1007,7 +1007,7 @@ char buf[64];
     buf[0] = 0x00;  // destination address, 0x00 = broadcast
     buf[1] = 0xEE;  // origin address, 0xEE = module, EdgeTx looks for this
 
-    strcpy(buf + 2, "MLRS " DEVICE_NAME);  // device name + versiononlystr too long
+    strcpy(buf + 2, "MLRS " DEVICE_NAME " " VERSIONONLYSTR);
     uint8_t name_len = strlen(buf + 2);
 
     tCrsfDeviceInfoFragment* dvif_ptr = (tCrsfDeviceInfoFragment*)(buf + name_len + 1);


### PR DESCRIPTION
- Adds addresses to device info
<del> - Removed version from device_name, otherwise it would be too long.  Example: 'mLRS ' + 20 char + ' v1.3.05' = 5 + 20 + 8 = 33 and can only be 32.
    - Note that we don't seem to enforce 20 char limit on the Tx side, e.g. BetaFPV Micro1W 2.4G is 21... </del> 

Somehow thought 32 char was the limit, this is not the case...

Tested working with BetaFPV Micro 1W on EdgeTx 2.11 RC2