### PR TITLE
mimic edgetx/elrs bind start

### DIFF
--- a/mLRS/Common/protocols/crsf_protocol.h
+++ b/mLRS/Common/protocols/crsf_protocol.h
@@ -110,6 +110,8 @@ typedef enum {
 
 // 0x32.0x10 Crossfire command options
 typedef enum {
+    CRSF_COMMAND_SET_BIND_MODE          = 0x01, // command to enter bind mode
+    CRSF_COMMAND_CANCEL_BIND_MODE       = 0x02, // command to cancel bind mode
     CRSF_COMMAND_SET_MODEL_SELECTION    = 0x05, // command to select model/receiver
     CRSF_COMMAND_QUERY_MODEL_SELECTION  = 0x06, // query frame of current selection
     CRSF_COMMAND_REPLY_MODEL_SELECTION  = 0x07, // reply frame of current selection

--- a/mLRS/CommonTx/mlrs-tx.cpp
+++ b/mLRS/CommonTx/mlrs-tx.cpp
@@ -1190,6 +1190,8 @@ IF_CRSF(
 //dbg.puts("\ncrsf model select id "); dbg.puts(u8toBCD_s(crsf.GetCmdModelId()));
             config_id.Change(crsf.GetCmdModelId());
             break;
+        case TXCRSF_CMD_BIND_START: start_bind(); break;
+        case TXCRSF_CMD_BIND_STOP: stop_bind(); break;
         case TXCRSF_CMD_MBRIDGE_IN:
 //dbg.puts("\ncrsf mbridge ");
             mbridge.ParseCrsfFrame(crsf.GetPayloadPtr(), crsf.GetPayloadLen());


### PR DESCRIPTION
@jlpoltrack 
this might be something to test out
it makes mLRS tell EdgeTx it is ELRS, such that EdgeTx should show the bind button in the crsf setup page. Pressing the bind button should put the tx module into bind mode indeed

this is not for merge but to test if this is working, so we eventually could consider doing a change to EdgeTx to get a bind button also for mLRS. (mLRS does not have an unbind mechanism, so this would work differently)