### PR TITLE
Esp half duplex improvements

### DIFF
--- a/mLRS/CommonTx/jr_pin5_interface_esp.h
+++ b/mLRS/CommonTx/jr_pin5_interface_esp.h
@@ -212,13 +212,14 @@ IRAM_ATTR void tPin5BridgeBase::pin5_rx_callback(uint8_t c)
         parse_nextchar(pin5_fifo.Get());
     }
 
-    // send telemetry after every received message
+    // can transmit now that entire message has been parsed
     if (state == STATE_TRANSMIT_START) {
         pin5_tx_enable();
         transmit_start();
         uart_is_transmitting = true;
-        state = STATE_IDLE;
     }
+    
+    state = STATE_IDLE;
 }
 
 


### PR DESCRIPTION
Updates to the ISR and the pin5_tx_enable function address the ghost byte caused by switching the pin.  This means that the callback is only triggered at the end of a message received from the radio.  All switching is done by the ISR as opposed to the mix that was there before.