### PR TITLE
tx,rx, 19 Hz 7x mode for sx127x

### DIFF
--- a/mLRS/Common/arq.h
+++ b/mLRS/Common/arq.h
@@ -205,6 +205,7 @@ void tTransmitArq::SetRetryCntAuto(int32_t _frame_cnt, uint8_t mode)
     case MODE_50HZ:
     case MODE_31HZ:
     case MODE_19HZ:
+    case MODE_19HZ_7X:
         SetRetryCnt((_frame_cnt >= 800) ? 2 : 1);
     }
 

--- a/mLRS/Common/bind.h
+++ b/mLRS/Common/bind.h
@@ -106,6 +106,10 @@ void tBindBase::Init(void)
 void tBindBase::ConfigForBind(void)
 {
     // switch to 19 Mode, select lowest possible power
+    // THIS IS DIRTY!
+    // we should determine if it should be MODE_19HZ or MODE_19HZ_7X
+    // however, configure_mode() does in fact do the same for both cases
+    // We could determined by checking #ifdef DEVICE_HAS_DUAL_SX127x. Is ok as also in device_conf.h.
     configure_mode(MODE_19HZ);
 
     sx.SetToIdle();

--- a/mLRS/Common/common_types.cpp
+++ b/mLRS/Common/common_types.cpp
@@ -168,22 +168,28 @@ uint8_t crsf_cvt_power(int8_t power_dbm)
 
 uint8_t crsf_cvt_mode(uint8_t mode)
 {
-    if (mode == MODE_19HZ) return 19;
-    if (mode == MODE_31HZ) return 31;
-    if (mode == MODE_50HZ) return CRSF_RFMODE_50_HZ;
-    if (mode == MODE_FLRC_111HZ) return 111;
-    if (mode == MODE_FSK_50HZ) return CRSF_RFMODE_50_HZ;
+    switch (mode) {
+    case MODE_50HZ: return CRSF_RFMODE_50_HZ;
+    case MODE_31HZ: return 31;
+    case MODE_19HZ: return 19;
+    case MODE_FLRC_111HZ: return 111;
+    case MODE_FSK_50HZ: return CRSF_RFMODE_50_HZ;
+    case MODE_19HZ_7X: return 19;
+    }
     return UINT8_MAX;
 }
 
 
 uint8_t crsf_cvt_fps(uint8_t mode)
 {
-    if (mode == MODE_19HZ) return 2; // *10 in OpenTx !
-    if (mode == MODE_31HZ) return 3;
-    if (mode == MODE_50HZ) return 5;
-    if (mode == MODE_FLRC_111HZ) return 11;
-    if (mode == MODE_FSK_50HZ) return 5;
+    switch (mode) {
+    case MODE_50HZ: return 5; // *10 in OpenTx !
+    case MODE_31HZ: return 3;
+    case MODE_19HZ: return 2;
+    case MODE_FLRC_111HZ: return 11;
+    case MODE_FSK_50HZ: return 5;
+    case MODE_19HZ_7X: return 2;
+    }
     return UINT8_MAX;
 }
 
@@ -391,6 +397,7 @@ void mode_str_to_strbuf(char* const s, uint8_t mode, uint8_t len)
         case MODE_19HZ: strbufstrcpy(s, "19Hz", len); break;
         case MODE_FLRC_111HZ: strbufstrcpy(s, "FLRC", len); break;
         case MODE_FSK_50HZ: strbufstrcpy(s, "FSK", len); break;
+        case MODE_19HZ_7X: strbufstrcpy(s, "19Hz7x", len); break;
         default: strbufstrcpy(s, "?", len);
     }
 }

--- a/mLRS/Common/setup_list.h
+++ b/mLRS/Common/setup_list.h
@@ -64,6 +64,9 @@
 #define SETUP_OPT_SERIAL_LINK_MODE_DISPSTR  "transp.,mavlink,mavlnkX,mspX"
 #endif
 
+#define SETUP_OPT_MODE                "50 Hz,31 Hz,19 Hz,FLRC,FSK,19 Hz 7x" // used below in LIST_COMMON, also used in e.g. cli
+#define SETUP_OPT_MODE_DISPSTR        "50 Hz,31 Hz,19 Hz,FLRC,FSK,19Hz7x" // used in display, 7 chars max, should be 6 chars however
+
 #define SETUP_OPT_RFBAND              "2.4,915 FCC,868,433,70,866 IN" // used below in LIST_COMMON
 #define SETUP_OPT_RF_BAND_LONGSTR     "2.4 GHz,915 MHz FCC,868 MHz,433 MHz,70 cm HAM,866 MHz IN" // used e.g. in cli
 #define SETUP_OPT_RF_BAND_DISPSTR     "2.4 GHz,915 FCC,868 MHz,433 MHz,70 cm,866 IN" // used in display, 7 chars max
@@ -82,7 +85,7 @@
   X( Setup.Common[0].BindPhrase[0], STR6, "Bind Phrase",      "BIND_PHRASE",      0,0,0,"", "", 0)
 
 #define SETUP_PARAMETER_LIST_COMMON_FURTHER \
-  X( Setup.Common[0].Mode,          LIST, "Mode",             "MODE",             0,0,0,"", "50 Hz,31 Hz,19 Hz,FLRC,FSK", SETUP_MSK_MODE )\
+  X( Setup.Common[0].Mode,          LIST, "Mode",             "MODE",             0,0,0,"", SETUP_OPT_MODE, SETUP_MSK_MODE )\
   X( Setup.Common[0].FrequencyBand, LIST, "RF Band",          "RF_BAND",          0,0,0,"", SETUP_OPT_RFBAND, SETUP_MSK_RFBAND )\
   X( Setup.Common[0].Ortho,         LIST, "RF Ortho",         "RF_ORTHO",         0,0,0,"", "off,1/3,2/3,3/3", SETUP_MSK_RFORTHO )
 

--- a/mLRS/Common/setup_types.h
+++ b/mLRS/Common/setup_types.h
@@ -55,6 +55,7 @@ typedef enum {
     MODE_19HZ,
     MODE_FLRC_111HZ,
     MODE_FSK_50HZ,
+    MODE_19HZ_7X,
     MODE_NUM,
 } MODE_ENUM;
 

--- a/mLRS/CommonRx/mavlink_interface_rx.h
+++ b/mLRS/CommonRx/mavlink_interface_rx.h
@@ -175,7 +175,7 @@ void tRxMavlink::Init(void)
 
 #ifdef USE_FEATURE_MAVLINKX
     fmavX_init();
-    fmavX_config_compression((Config.Mode == MODE_19HZ) ? 1 : 0); // use compression only in 19 Hz mode
+    fmavX_config_compression((Config.Mode == MODE_19HZ || Config.Mode == MODE_19HZ_7X) ? 1 : 0); // use compression only in 19 Hz mode
 
     status_serial_in = {};
     fifo_link_out.Init();
@@ -416,7 +416,8 @@ void tRxMavlink::parse_link_in_serial_out(char c)
             case MODE_50HZ:
             case MODE_FSK_50HZ: force_param_list = (Config.SerialBaudrate > 115200); break; // 115200 bps and lower is ok for mftp
             case MODE_31HZ: force_param_list = (Config.SerialBaudrate > 57600); break; // 57600 bps and lower is ok for mftp
-            case MODE_19HZ: force_param_list = (Config.SerialBaudrate > 38400); break; // 38400 bps and lower is ok for mftp
+            case MODE_19HZ:
+            case MODE_19HZ_7X: force_param_list = (Config.SerialBaudrate > 38400); break; // 38400 bps and lower is ok for mftp
             }
             if (autopilot.HasMFtpFlowControl()) force_param_list = false; // mftp is flow controlled, so always ok
 #endif
@@ -990,7 +991,7 @@ uint16_t tx_ser_data_rate, rx_ser_data_rate;
         tx_ser_data_rate = 2000;
         rx_ser_data_rate = 2562;
         break;
-    case MODE_19HZ:
+    case MODE_19HZ: case MODE_19HZ_7X:
         tx_ser_data_rate = 1207;
         rx_ser_data_rate = 1547;
         break;

--- a/mLRS/CommonTx/cli.h
+++ b/mLRS/CommonTx/cli.h
@@ -59,6 +59,9 @@ uint8_t nr, n;
         if (SetupParameter[param_idx].ptr == &(Setup.Common[0].FrequencyBand)) { // RF Band
             optstr = SETUP_OPT_RF_BAND_DISPSTR;
         }
+        if (SetupParameter[param_idx].ptr == &(Setup.Common[0].Mode)) { // Mode
+            optstr = SETUP_OPT_MODE_DISPSTR;
+        }
         if ((SetupParameter[param_idx].ptr == &(Setup.Tx[0].Diversity)) ||
             (SetupParameter[param_idx].ptr == &(Setup.Rx.Diversity))) {
             optstr = SETUP_OPT_DIVERSITY_DISPSTR;

--- a/mLRS/CommonTx/disp.h
+++ b/mLRS/CommonTx/disp.h
@@ -706,9 +706,9 @@ int8_t power;
     draw_header("Main");
 
     gdisp_setcurX(50);
-    param_get_val_formattedstr(s, PARAM_INDEX_MODE); // 1 = index of Mode
+    param_get_val_formattedstr(s, PARAM_INDEX_MODE, PARAM_FORMAT_DISPLAY); // 1 = index of Mode
     if (strlen(s) > 5) {
-        gdisp_setcurXY(35, 6);
+        gdisp_setcurXY(43, 6);
     } else {
         gdisp_setcurXY(50, 6);
     }

--- a/mLRS/CommonTx/mavlink_interface_tx.h
+++ b/mLRS/CommonTx/mavlink_interface_tx.h
@@ -166,7 +166,7 @@ void tTxMavlink::Init(tSerialBase* const _serialport, tSerialBase* const _mbridg
 
 #ifdef USE_FEATURE_MAVLINKX
     fmavX_init();
-    fmavX_config_compression((Config.Mode == MODE_19HZ) ? 1 : 0); // use compression only in 19 Hz mode
+    fmavX_config_compression((Config.Mode == MODE_19HZ || Config.Mode == MODE_19HZ_7X) ? 1 : 0); // use compression only in 19 Hz mode
 
     status_ser_in = {};
     status_ser2_in = {};


### PR DESCRIPTION
title says it

the sx1276 chip set is not compatible with the sx126x, which can confuse, and also in view of LR1121 support (which can do both) we should distinguish between the 19 Hz mode for sx126x and sx127x.

we had a discussion on this before and the suggestion was to call this new mode "19 Hz 7x"

I've tested it somewhat and am hopeful, but it would be great to see you guys also looking over it and testing it.
It should be possible to falsh teh devices back and forth without issues.

