### PR TITLE
ESP32 Faster Flash

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,8 +28,8 @@ build_flags = -Os
 
 [env_common_esp32]
 platform = espressif32@6.6.0
-;board_build.f_flash = 80000000L
-;board_build.flash_mode = qio
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
 board_build.f_cpu = 240000000L
 build_type = release
 build_flags =
@@ -40,8 +40,6 @@ build_flags =
   -D CONFIG_SPI_MASTER_IN_IRAM=1
   -D CONFIG_UART_ISR_IN_IRAM=1
   -D CONFIG_I2C_ISR_IRAM_SAFE=1
-;  -D CONFIG_ARDUINO_ISR_IRAM=1
-;  -D CONFIG_FREERTOS_UNICORE=1
   -O2
 build_unflags = -Os
 


### PR DESCRIPTION
Use 80 MHz and QIO for flash instead of 40 MHz and DIO - flash should be ~4x faster on ESP32.  This is now the default in the Arduino IDE.

As ESP32 has big (32 kB) cache, this change doesn't have much of an impact on receiver perofrmance but it helps out quite a bit on the Tx side - loop rate is ~5% faster, max loop time and jitter decrease.

@brad112358 @tmcadam perhaps you could check to see if you can correlate these observations.

This will also require a small update to the Desktop App, will do that when/if this is closer to being merged.