### PR TITLE
Bridge configuration without GPIO0 connection

### DIFF
--- a/mLRS/Common/hal/stm32/tx-hal-R9M-868-f103c8.h
+++ b/mLRS/Common/hal/stm32/tx-hal-R9M-868-f103c8.h
@@ -21,7 +21,8 @@
 #define DEVICE_HAS_DEBUG_SWUART
 #define DEVICE_HAS_BUZZER
 #define DEVICE_HAS_FAN_ONOFF
-
+#define DEVICE_HAS_ESP_WIFI_BRIDGE_ON_SERIAL
+#define DEVICE_HAS_ESP_WIFI_BRIDGE_CONFIGURE
 // Note on SERIAL_OR_COM:
 // The com uart is not initialized, the serial uart is, So, buffers are set as by the RX/TXBUFSIZE defines for serial.
 // The TXBUFSIZE setting for the com affects however the CLI's chunkenizer behavior.
@@ -274,6 +275,23 @@ void fan_set_power(int8_t power_dbm)
     }
 }
 
+//-- Wifi Bridge
+
+#define ESP_RESET                 // defined, but unused
+#define ESP_GPIO0                 // defined, but unused
+
+#ifdef DEVICE_HAS_ESP_WIFI_BRIDGE_ON_SERIAL
+void esp_init(void)
+{
+}
+
+void esp_reset_high(void) {}
+void esp_reset_low(void) {}
+
+void esp_gpio0_high(void) {}
+void esp_gpio0_low(void) {}
+
+#endif
 
 //-- POWER
 


### PR DESCRIPTION
Allow AT mode configuration at power on for bridges without gpio0 connected 
Demonstrate power on wireless bridge configuration on R9M tx

Tested on pocket internal elrs and RM9M + M5 stamp pico

Note; this also speeds up configuration just a bit with GPIO0 in some cases by removing the fixed delay and relying on the retry/baud loops.  The maximum total delay is now about the same as before we increased ESP_CMDRES_TMO_MS from 50 to 70 in the last PR.

This is working quite reliably now both with and without GPIO0 and reset connected.  Obviously, when we don't have reset, we need to power cycle the Tx/bridge manually when the bridge configuration is changed.