### PR TITLE
B&W Lua: Make reload always jump back to the first page.

### DIFF
--- a/lua/mLRS-bw.lua
+++ b/lua/mLRS-bw.lua
@@ -881,7 +881,9 @@ local function doPage(event)
             elseif page == 0 and cursor_idx == Boot_idx then -- Boot pressed
                 sendBoot()
             elseif cursor_idx == Reload_idx - s then -- Reload pressed
+                page = 0  -- move to page 0 to force MBRIDGE_CMD_REQUEST_INFO
                 clearParms()
+                cursor_idx = 9
             elseif cursor_idx == Prev_idx - s then -- Prev pressed
                 clearParms()
                 page = page - 1


### PR DESCRIPTION
This causes MBRIDGE_CMD_REQUEST_INFO to be sent sent so that setup.h:setup_reload() will be called to reload the parameters from NV.

Fixes #334 