### PR TITLE
Gitignore, ds store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ mLRS/*/Drivers/STM32??xx_HAL_Driver/*
 mLRS/*/Drivers/STM32_USB_Device_Library/*
 .pio
 .vscode
+.DS_Store
 
 # Prerequisites
 *.d


### PR DESCRIPTION
MacOS creates these files that store metadata, so should ignore them.