### PR TITLE
Override stm32cube IDE dirs via OS env

### DIFF
--- a/tools/run_make_firmwares.py
+++ b/tools/run_make_firmwares.py
@@ -87,6 +87,10 @@ if __name__ == "__main__":
         st_root = os.path.join("/opt",'st')
 
     ST_DIR,GNU_DIR = findSTM32CubeIDEGnuTools(st_root)
+    if os.getenv("MLRS_ST_DIR"):
+        ST_DIR = os.getenv("MLRS_ST_DIR")
+    if os.getenv("MLRS_GNU_DIR"):
+        GNU_DIR = os.getenv("MLRS_GNU_DIR")
 
     if ST_DIR == '' or GNU_DIR == '' or not os.path.exists(os.path.join(ST_DIR,GNU_DIR)):
         print('ERROR: gnu-tools not found!')


### PR DESCRIPTION
KISS way to override toolchain dirs for your needs.
```
export MLRS_ST_DIR="/Users/username/Applications/STM32CubeIDE.app"
export MLRS_GNU_DIR="Contents/Eclipse/plugins/com.st.stm32cube.ide.mcu.externaltools.gnu-tools-for-stm32.12.3.rel1.macos64_1.0.100.202403111906/"
python tools/run_make_firmwares.py
```

