### PR TITLE
common, setup, adjust mode according to hardware capabilities

### DIFF
--- a/mLRS/Common/setup.h
+++ b/mLRS/Common/setup.h
@@ -386,9 +386,9 @@ void setup_sanitize_config(uint8_t config_id)
     }
     TST_NOTALLOWED_TYPED(FrequencyBand_allowed_mask, Common[config_id].FrequencyBand, frequency_band_default, SETUP_FREQUENCY_BAND_ENUM);
 
-#if defined FREQUENCY_BAND_2P4_GHZ && defined FREQUENCY_BAND_915_MHZ_FCC && defined FREQUENCY_BAND_868_MHZ
-    // MULTIBAND
-    // we now know the band, so can adjust the allowed mask for Mode and Ortho (Ortho is done below)
+#ifdef DEVICE_HAS_LR11xx
+    // MULTIBAND capable hardware, so adjust allowed modes for hardware capabilities
+    // we now know the frequency band, so can adjust the allowed mask for Mode and Ortho (Ortho is done below)
     switch (Setup.Common[config_id].FrequencyBand) {
     case SETUP_FREQUENCY_BAND_2P4_GHZ:
         SetupMetaData.Mode_allowed_mask &= 0b000111; // filter down to 50 Hz, 31 Hz, 19 Hz


### PR DESCRIPTION
@jlpoltrack 
see code change
I believe that this line was incorrect, as the allowed modes need to be adjusted according to the capabilities of the hardware.

For instance, for the LR2021, one would allow also FLRC for 2.4GHz, that is the current bit mask would not apply.

I'd like you to double check and confrim that is still doing the right thing for the lr1121