### PR TITLE
tx, no bind or passthrough while connected

### DIFF
--- a/mLRS/CommonTx/mlrs-tx.cpp
+++ b/mLRS/CommonTx/mlrs-tx.cpp
@@ -818,11 +818,13 @@ INITCONTROLLER_END
                 }
             }
 
-            bind.Tick_ms();
+            if (!connected()) {  // no bind or passthrough when connected
+                bind.Tick_ms();
+                esp.Tick_ms();
+            }
             disp.Tick_ms(); // can take long
             fan.SetPower(sx.RfPower_dbm());
             fan.Tick_ms();
-            esp.Tick_ms();
 
             if (!tick_1hz) {
                 dbg.puts(".");


### PR DESCRIPTION
IMO, shouldn't allow bind or passthrough while connected.  Noticed that the Tx had entered passthrough when I put radio down and one of the buttons ended was being pressed.

Edit - suppose bind should be disabled for Rx too...