### PR TITLE
MSP Rx Reboot

### DIFF
--- a/mLRS/Common/protocols/msp_protocol.h
+++ b/mLRS/Common/protocols/msp_protocol.h
@@ -153,6 +153,16 @@ typedef struct
 #define MSP_SONAR_ALTITUDE_LEN  4
 
 
+// MSP_REBOOT  68
+MSP_PACKED(
+typedef struct
+{
+    uint32_t magic;
+}) tMspReboot;
+
+#define MSP_REBOOT_LEN  4
+
+
 // MSP_STATUS  101
 //      cycleTime   UINT 16   unit: microseconds
 //      i2c_errors_count  UINT 16


### PR DESCRIPTION
For future INAV Passthrough functionality, use the MSP Reboot command to put STM32 receivers into system bootloader.

Tested in combination with: https://jlpoltrack.github.io/mLRS-Flasher/inav-passthrough/

Requires: https://github.com/iNavFlight/inav/pull/11256