### PR TITLE
ESP32C3 undef min max in glue

### DIFF
--- a/mLRS/Common/hal/esp-glue.h
+++ b/mLRS/Common/hal/esp-glue.h
@@ -15,6 +15,10 @@
 #include "esp_task_wdt.h"
 #endif
 
+// undefine MIN/MAX from to prevent redefinition when stdstm32.h is included later
+#undef MIN
+#undef MAX
+
 #define __NOP() _NOP()
 
 


### PR DESCRIPTION
Gets rid of compiler warnings because stdstm32.h redefines min / max functions.