### PR TITLE
Disp Y Offset

### DIFF
--- a/mLRS/CommonTx/disp.h
+++ b/mLRS/CommonTx/disp.h
@@ -54,7 +54,7 @@ void i2c_spin(uint16_t chunksize);
 
 // y-offset for content below header; 20 was original value, use 22 for dual-color OLEDs
 #ifndef DISP_CONTENT_Y_BASE
-  #define DISP_CONTENT_Y_BASE               20
+  #define DISP_CONTENT_Y_BASE   20
 #endif
 
 


### PR DESCRIPTION
Adds a define for the Y Offset on the OLED Displays.

Does add 1 position tweak for the Rx settings screen when there is no receiver connected - move this down 4 pixels.

Couldn't see any issues with 22 on single color OLEDs but kept at 20, so should be NFC.