### PR TITLE
wireless, Fix UDP STA bug - New code requires empty password variable

### DIFF
--- a/esp/mlrs-wireless-bridge/mlrs-wireless-bridge.ino
+++ b/esp/mlrs-wireless-bridge/mlrs-wireless-bridge.ino
@@ -128,7 +128,7 @@ int port_udp = 14550; // connect to this port per UDP // MissionPlanner default 
 // - a default password which includes the mLRS bindphrase, like "mLRS-mlrs.0"
 // for UDPCl both strings MUST be set to what your Wifi network requires
 String network_ssid = ""; // name of your WiFi network
-String network_password = "****"; // password to access your WiFi network (min 8 chars)
+String network_password = ""; // password to access your WiFi network (min 8 chars)
 
 IPAddress ip_udpcl(192, 168, 0, 164); // your network's IP (only for UDPCl) // MissionPlanner default is 127.0.0.1, so enter your home's IP in MP
 


### PR DESCRIPTION
This is what was blocking my progress in testing with the internal Tx module on my RM pocket.  The new wireless code assumes a non-empty password means a valid password was set in the code and then the default password doesn't get used and UDP STA is unusable since the internal module has no CLI to set the password.

Note, I did test Mission planner with UDP STA (My phone provided the hot spot for both windows and the bridge) and the default settings connected just fine without having to specify an IP address.  @olliw42 I'm not sure what you are doing different.