### PR TITLE
LR No Buffer Base

### DIFF
--- a/mLRS/Common/sx-drivers/lr11xx_driver.h
+++ b/mLRS/Common/sx-drivers/lr11xx_driver.h
@@ -266,8 +266,6 @@ class Lr11xxDriverCommon : public Lr11xxDriverBase
 
         SetRfPower_dbm(gconfig->Power_dbm);
 
-        SetBufferBaseAddress(0, 0);
-
         ClearIrq(LR11XX_IRQ_ALL);
 
         SetFs();


### PR DESCRIPTION
LRxx doesn't have the SetBufferBaseAddress command.  Fixes compile error.