### PR TITLE
LR2021 DIO RF Config

### DIFF
--- a/mLRS/Common/sx-drivers/lr20xx.cpp
+++ b/mLRS/Common/sx-drivers/lr20xx.cpp
@@ -188,7 +188,7 @@ void Lr20xxDriverBase::SetDioRfSwitchConfig(uint8_t Dio, uint8_t Config)
 uint8_t buf[2];
 
     buf[0] = Dio; // allowed values are 5 - 11
-    buf[1] = (Config);
+    buf[1] = (Config & 0x1F);
 
     WriteCommand(LR20XX_CMD_SET_DIO_RF_SWITCH_CONFIG, buf, 2);
 }


### PR DESCRIPTION
Was missing the DIO pin, aligned to datasheet:

<img width="902" height="282" alt="image" src="https://github.com/user-attachments/assets/2f9a0c4d-a45a-4f89-9297-73db089938e9" />