### PR TITLE
DroneCAN getbuf

### DIFF
--- a/mLRS/CommonRx/dronecan_interface_rx.h
+++ b/mLRS/CommonRx/dronecan_interface_rx.h
@@ -473,6 +473,13 @@ uint8_t tRxDroneCan::getc(void)
 }
 
 
+void tRxDroneCan::getbuf(uint8_t* const buf, uint16_t len)
+{
+    tunnel_targetted_stats.fc_to_ser_rate += len;
+    for (uint16_t i = 0; i < len; i++) buf[i] = fifo_fc_to_ser.Get();
+}
+
+
 void tRxDroneCan::flush(void)
 {
     fifo_fc_to_ser.Flush();

--- a/mLRS/CommonRx/dronecan_interface_rx_types.h
+++ b/mLRS/CommonRx/dronecan_interface_rx_types.h
@@ -49,6 +49,7 @@ class tRxDroneCan
     void putbuf(uint8_t* const buf, uint16_t len);
     bool available(void);
     uint8_t getc(void);
+    void getbuf(uint8_t* const buf, uint16_t len);
     void flush(void);
     uint16_t bytes_available(void);
 


### PR DESCRIPTION
Add getbuf method to DroneCAN.

If merged, will follow-up with update to common and common_types to include getbuf methods.