### PR TITLE
Use sys.executable to invoke dronescan_dsdlc.py

### DIFF
--- a/mLRS/Common/dronecan/dronecan_generate_c_library.py
+++ b/mLRS/Common/dronecan/dronecan_generate_c_library.py
@@ -47,7 +47,7 @@ def generate_dsdl():
     #os.chdir(os.path.join(mLRSdirectory,'Common','mavlink'))
     
     os_system(
-        os.path.join('..','..','modules','dronecan','dronecan_dsdlc','dronecan_dsdlc.py')
+        sys.executable + ' ' + os.path.join('..','..','modules','dronecan','dronecan_dsdlc','dronecan_dsdlc.py')
         + ' -O ' + os.path.join(outdir)
         + ' ' + os.path.join('..','..','modules','dronecan','DSDL','dronecan')
         + ' ' + os.path.join('..','..','modules','dronecan','DSDL','uavcan')


### PR DESCRIPTION
On systems where only `python3` is available (not `python`), calling `dronecan_dsdlc.py` directly via `os.system()` relies on the script's shebang (`#!/usr/bin/env python`), which fails with `/usr/bin/env: 'python': No such file or directory`.

**Fix:** Prepend `sys.executable` to the command in `generate_dsdl()` so the same interpreter already running `dronecan_generate_c_library.py` is reused.

**Tested on:** Ubuntu 24.04 (WSL2) where `python3` is installed but `python` is not.