### PR TITLE
Introduce SERIAL_FIXED_BAUD define to lock serial baud

### DIFF
--- a/mLRS/CommonTx/mlrs-tx.cpp
+++ b/mLRS/CommonTx/mlrs-tx.cpp
@@ -709,7 +709,11 @@ RESTARTCONTROLLER
     init_hw();
     DBG_MAIN(dbg.puts("\n\n\nHello\n\n");)
 
+#ifdef SERIAL_FIXED_BAUD
+    serial.SetBaudRate(SERIAL_FIXED_BAUD); // ignore user parameter
+#else
     serial.SetBaudRate(Config.SerialBaudrate);
+#endif
     serial2.SetBaudRate(Config.SerialBaudrate);
 
     // startup sign of life


### PR DESCRIPTION
This is needed for the RadioMaster AX12
