### PR TITLE
Don't require correct serial port selection for wireless bridge flashing

### DIFF
--- a/mLRS/CommonTx/esp.h
+++ b/mLRS/CommonTx/esp.h
@@ -187,16 +187,12 @@ void tTxEspWifiBridge::Init(
 
     com = _comport;
     ser = nullptr;
-    if (tx_setup->SerialDestination == SERIAL_DESTINATION_SERIAL) {
 #ifdef DEVICE_HAS_ESP_WIFI_BRIDGE_ON_SERIAL
-        ser = _serialport;
+    ser = _serialport;
 #endif
-    } else
-    if (tx_setup->SerialDestination == SERIAL_DESTINATION_SERIAL2) {
 #ifdef DEVICE_HAS_ESP_WIFI_BRIDGE_ON_SERIAL2
-        ser = _serial2port;
+    ser = _serial2port;
 #endif
-    }
     ser_baud = _serial_baudrate;
 
     passthrough = (com != nullptr && ser != nullptr); // we need both for passthrough


### PR DESCRIPTION
The run time checking here is unnecessary and was problematic when I was trying to flash the wireless bridge on the AX12 before we had a working Lua script.  Removing this removes a step when flashing and should result in fewer user errors.