### PR TITLE
tools, run_make_firmwares, arm-none-eabi toolchain on PATH (no CubeIDE)

### DIFF
--- a/tools/run_make_firmwares.py
+++ b/tools/run_make_firmwares.py
@@ -9,7 +9,7 @@
  run_make_firmwares.py
  3rd version, doesn't use make but calls gnu directly
  gave up on cmake, hence naive by hand
- version 7.05.2026
+ version 5.06.2026
 ********************************************************
 '''
 import os

--- a/tools/run_make_firmwares.py
+++ b/tools/run_make_firmwares.py
@@ -78,7 +78,7 @@ def findSTM32CubeIDEGnuTools(search_root):
     return st_dir, gnu_dir
 
 
-ST_DIR,GNU_DIR = '', ''
+ST_DIR,GNU_DIR,GCC_DIR = '', '', ''
 
 # do this only when called from main context
 if __name__ == "__main__":
@@ -92,35 +92,20 @@ if __name__ == "__main__":
     if os.getenv("MLRS_GNU_DIR"):
         GNU_DIR = os.getenv("MLRS_GNU_DIR")
 
-    if ST_DIR == '' or GNU_DIR == '' or not os.path.exists(os.path.join(ST_DIR,GNU_DIR)):
+    if ST_DIR != '' and GNU_DIR != '' and os.path.exists(os.path.join(ST_DIR,GNU_DIR)):
+        # STM32CubeIDE toolchain, gnu-tools live in a tools/bin subpath of the plugin
+        GCC_DIR = os.path.join(ST_DIR,GNU_DIR,'tools','bin')
+        print('STM32CubeIDE found in:', ST_DIR)
+        print('gnu-tools found in:', GNU_DIR)
+    else:
         # no STM32CubeIDE toolchain found, fall back to a standalone arm-none-eabi toolchain on PATH
         gcc_path = shutil.which('arm-none-eabi-gcc')
         if not gcc_path:
             print('ERROR: gnu-tools not found! (neither STM32CubeIDE nor arm-none-eabi-gcc on PATH)')
             exit(1)
-        # arm-none-eabi-gcc is directly on PATH: ST_DIR is its bin dir and GNU_DIR stays
-        # empty (no CubeIDE plugin/tools subpath), which GCC_DIR below keys off of
-        ST_DIR = os.path.dirname(gcc_path)
-        GNU_DIR = ''
-
-    if GNU_DIR:
-        print('STM32CubeIDE found in:', ST_DIR)
-        print('gnu-tools found in:', GNU_DIR)
-    else:
-        print('arm-none-eabi toolchain found in:', ST_DIR)
+        GCC_DIR = os.path.dirname(gcc_path) # arm-none-eabi-gcc is directly in this dir
+        print('arm-none-eabi toolchain found in:', GCC_DIR)
     print('------------------------------------------------------------')
-
-
-#-- GCC preliminaries
-
-GCC_DIR = os.path.join(ST_DIR,GNU_DIR,'tools','bin') if GNU_DIR else ST_DIR
-
-# we need to modify the PATH so that the correct toolchain/compiler is used
-# why does sys.path.insert(0,xxx) not work?
-# no, not needed anymore as we can call arm-none-eabi directly
-#envpath = os.environ["PATH"]
-#envpath = GCC_DIR + ';' + envpath
-#os.environ["PATH"] = envpath
 
 
 #-- mLRS directories

--- a/tools/run_make_firmwares.py
+++ b/tools/run_make_firmwares.py
@@ -79,6 +79,7 @@ def findSTM32CubeIDEGnuTools(search_root):
 
 
 ST_DIR,GNU_DIR = '', ''
+GCC_DIR_OVERRIDE = '' # set when a standalone arm-none-eabi toolchain on PATH is used instead of CubeIDE
 
 # do this only when called from main context
 if __name__ == "__main__":
@@ -93,17 +94,24 @@ if __name__ == "__main__":
         GNU_DIR = os.getenv("MLRS_GNU_DIR")
 
     if ST_DIR == '' or GNU_DIR == '' or not os.path.exists(os.path.join(ST_DIR,GNU_DIR)):
-        print('ERROR: gnu-tools not found!')
-        exit(1)
-
-    print('STM32CubeIDE found in:', ST_DIR)
-    print('gnu-tools found in:', GNU_DIR)
+        # no STM32CubeIDE toolchain found, fall back to a standalone arm-none-eabi toolchain on PATH
+        gcc_path = shutil.which('arm-none-eabi-gcc')
+        if gcc_path:
+            GCC_DIR_OVERRIDE = os.path.dirname(gcc_path)
+            print('STM32CubeIDE not found, using arm-none-eabi toolchain on PATH:')
+            print(GCC_DIR_OVERRIDE)
+        else:
+            print('ERROR: gnu-tools not found! (neither STM32CubeIDE nor arm-none-eabi-gcc on PATH)')
+            exit(1)
+    else:
+        print('STM32CubeIDE found in:', ST_DIR)
+        print('gnu-tools found in:', GNU_DIR)
     print('------------------------------------------------------------')
 
 
 #-- GCC preliminaries
 
-GCC_DIR = os.path.join(ST_DIR,GNU_DIR,'tools','bin')
+GCC_DIR = GCC_DIR_OVERRIDE if GCC_DIR_OVERRIDE else os.path.join(ST_DIR,GNU_DIR,'tools','bin')
 
 # we need to modify the PATH so that the correct toolchain/compiler is used
 # why does sys.path.insert(0,xxx) not work?

--- a/tools/run_make_firmwares.py
+++ b/tools/run_make_firmwares.py
@@ -103,8 +103,11 @@ if __name__ == "__main__":
         ST_DIR = os.path.dirname(gcc_path)
         GNU_DIR = ''
 
-    print('STM32CubeIDE found in:', ST_DIR)
-    print('gnu-tools found in:', GNU_DIR)
+    if GNU_DIR:
+        print('STM32CubeIDE found in:', ST_DIR)
+        print('gnu-tools found in:', GNU_DIR)
+    else:
+        print('arm-none-eabi toolchain found in:', ST_DIR)
     print('------------------------------------------------------------')
 
 

--- a/tools/run_make_firmwares.py
+++ b/tools/run_make_firmwares.py
@@ -79,7 +79,6 @@ def findSTM32CubeIDEGnuTools(search_root):
 
 
 ST_DIR,GNU_DIR = '', ''
-GCC_DIR_OVERRIDE = '' # set when a standalone arm-none-eabi toolchain on PATH is used instead of CubeIDE
 
 # do this only when called from main context
 if __name__ == "__main__":
@@ -96,22 +95,22 @@ if __name__ == "__main__":
     if ST_DIR == '' or GNU_DIR == '' or not os.path.exists(os.path.join(ST_DIR,GNU_DIR)):
         # no STM32CubeIDE toolchain found, fall back to a standalone arm-none-eabi toolchain on PATH
         gcc_path = shutil.which('arm-none-eabi-gcc')
-        if gcc_path:
-            GCC_DIR_OVERRIDE = os.path.dirname(gcc_path)
-            print('STM32CubeIDE not found, using arm-none-eabi toolchain on PATH:')
-            print(GCC_DIR_OVERRIDE)
-        else:
+        if not gcc_path:
             print('ERROR: gnu-tools not found! (neither STM32CubeIDE nor arm-none-eabi-gcc on PATH)')
             exit(1)
-    else:
-        print('STM32CubeIDE found in:', ST_DIR)
-        print('gnu-tools found in:', GNU_DIR)
+        # arm-none-eabi-gcc is directly on PATH: ST_DIR is its bin dir and GNU_DIR stays
+        # empty (no CubeIDE plugin/tools subpath), which GCC_DIR below keys off of
+        ST_DIR = os.path.dirname(gcc_path)
+        GNU_DIR = ''
+
+    print('STM32CubeIDE found in:', ST_DIR)
+    print('gnu-tools found in:', GNU_DIR)
     print('------------------------------------------------------------')
 
 
 #-- GCC preliminaries
 
-GCC_DIR = GCC_DIR_OVERRIDE if GCC_DIR_OVERRIDE else os.path.join(ST_DIR,GNU_DIR,'tools','bin')
+GCC_DIR = os.path.join(ST_DIR,GNU_DIR,'tools','bin') if GNU_DIR else ST_DIR
 
 # we need to modify the PATH so that the correct toolchain/compiler is used
 # why does sys.path.insert(0,xxx) not work?


### PR DESCRIPTION
Allows one to use arm toolchain instead of requiring CubeIDE.

Tested on MacOS only.