### PR TITLE
serial class updates

### DIFF
--- a/mLRS/Common/common.h
+++ b/mLRS/Common/common.h
@@ -173,8 +173,8 @@ tSerialBase* tSerialPorts::com_port(void) { // uartc or usb
 
 void tSerialPorts::set_serial_com_swapped(void)
 {
-    serial = &uartb_port;
-    com = com_port();
+    serial = com_port();
+    com = &uartb_port;
 }
 
 
@@ -196,14 +196,11 @@ tSerialBase* tSerialPorts::ser_or_com_set_to_com(void)
 
 void tSerialPorts::Init(uint8_t serial_destination, uint32_t baud)
 {
-#if defined USE_COM_ON_SERIAL || defined DEVICE_HAS_SERIAL_OR_COM // device has a button to force com/cli
-    if (!ser_or_com_init()) { serial_destination = 0; } // force default
-#endif
-
     switch (serial_destination) {
     case SERIAL_DESTINATION_SERIAL2:
         serial = &uartd_port;
         com = com_port();
+        break;
     case SERIAL_DESTINATION_COM:
         set_serial_com_swapped();
         break;
@@ -211,6 +208,19 @@ void tSerialPorts::Init(uint8_t serial_destination, uint32_t baud)
         serial = &uartb_port;
         com = com_port();
     }
+
+#if defined USE_COM_ON_SERIAL || defined DEVICE_HAS_SERIAL_OR_COM // device has a button to force com/cli
+    // button pressed on power up -> force com/cli, serial2 stays on uartD
+    if (!ser_or_com_init()) {
+  #if defined DEVICE_HAS_COM_ON_USB
+        if (serial == &usb_port) serial = &uartb_port; // undo a "com" destination swap; com goes back to usb
+        com = &usb_port;
+  #else
+        if (serial == &uartb_port) serial = com_port(); // free the uartB pins for com (serial -> dummy uartC)
+        com = &uartb_port;
+  #endif
+    }
+#endif
 
     jrpin5serial = nullptr;
 

--- a/mLRS/Common/common.h
+++ b/mLRS/Common/common.h
@@ -196,7 +196,7 @@ tSerialBase* tSerialPorts::ser_or_com_set_to_com(void)
 
 void tSerialPorts::Init(uint8_t serial_destination, uint32_t baud)
 {
-#if defined USE_COM_ON_SERIAL // button forces com onto the uartB serial pins (no separate com port)
+#if defined USE_COM_ON_SERIAL && defined DEVICE_HAS_SERIAL_OR_COM // button forces com onto the uartB serial pins (no separate com port)
     if (!ser_or_com_init()) { serial_destination = SERIAL_DESTINATION_COM; } // force swap
 #elif defined DEVICE_HAS_SERIAL_OR_COM // button forces com onto usb
     if (!ser_or_com_init()) { serial_destination = 0; } // force default

--- a/mLRS/Common/common.h
+++ b/mLRS/Common/common.h
@@ -196,6 +196,12 @@ tSerialBase* tSerialPorts::ser_or_com_set_to_com(void)
 
 void tSerialPorts::Init(uint8_t serial_destination, uint32_t baud)
 {
+#if defined USE_COM_ON_SERIAL // button forces com onto the uartB serial pins (no separate com port)
+    if (!ser_or_com_init()) { serial_destination = SERIAL_DESTINATION_COM; } // force swap
+#elif defined DEVICE_HAS_SERIAL_OR_COM // button forces com onto usb
+    if (!ser_or_com_init()) { serial_destination = 0; } // force default
+#endif
+
     switch (serial_destination) {
     case SERIAL_DESTINATION_SERIAL2:
         serial = &uartd_port;
@@ -208,19 +214,6 @@ void tSerialPorts::Init(uint8_t serial_destination, uint32_t baud)
         serial = &uartb_port;
         com = com_port();
     }
-
-#if defined USE_COM_ON_SERIAL || defined DEVICE_HAS_SERIAL_OR_COM // device has a button to force com/cli
-    // button pressed on power up -> force com/cli, serial2 stays on uartD
-    if (!ser_or_com_init()) {
-  #if defined DEVICE_HAS_COM_ON_USB
-        if (serial == &usb_port) serial = &uartb_port; // undo a "com" destination swap; com goes back to usb
-        com = &usb_port;
-  #else
-        if (serial == &uartb_port) serial = com_port(); // free the uartB pins for com (serial -> dummy uartC)
-        com = &uartb_port;
-  #endif
-    }
-#endif
 
     jrpin5serial = nullptr;
 

--- a/mLRS/Common/hal/hal.h
+++ b/mLRS/Common/hal/hal.h
@@ -278,6 +278,7 @@ extern "C" { void delay_ms(uint16_t ms); }
 #ifdef DEVICE_HAS_COM_ON_SERIAL // some devices have device dependent ways to select serial or com
   #define USE_SERIAL
   #define USE_COM_ON_SERIAL
+  #define DEVICE_HAS_SERIAL_OR_COM // COM_ON_SERIAL implies HAS_SERIAL_OR_COM (button forces com onto the serial pins)
 #else
   #if !defined DEVICE_HAS_NO_SERIAL
     #define USE_SERIAL

--- a/mLRS/CommonTx/hc04.h
+++ b/mLRS/CommonTx/hc04.h
@@ -48,7 +48,7 @@ extern tTxDisp disp;
 class tTxHc04Bridge
 {
   public:
-    void Init(tSerialPorts* const _serialports, uint32_t const _serial_baudratet, tTxSetup* const _tx_setup);
+    void Init(tSerialPorts* const _serialports, uint32_t const _serial_baudrate, tTxSetup* const _tx_setup);
 
     void EnterPassthrough(void);
     void GetPin(void);


### PR DESCRIPTION
  - Fix missing break in tSerialPorts::Init
  - Fix set_serial_com_swapped() to actually swap 
  - Correct the power-up button (force-com) path per board class
  - Fix parameter-name typo in tTxHc04Bridge::Init