### PR TITLE
Serial routing updates

### DIFF
--- a/mLRS/Common/common.h
+++ b/mLRS/Common/common.h
@@ -149,7 +149,7 @@ typedef struct
     tSerialBase* serial; // assigned according to TxSerDest
     tSerialBase* com; // assigned according to TxSerDest
     tSerialBase* serial2; // can be nullptr!
-    tSerialBase* jrpin5serial; // can be nullptr! initialized in tPin5BridgeBase.Init()
+    tSerialBase* jrpin5serial; // can be nullptr! assigned in init_hw() if DEVICE_HAS_ESP_WIFI_BRIDGE_W_PASSTHRU_VIA_JRPIN5, else stays nullptr
     tSerialBase* uartb; // serial port
     tSerialBase* uartd; // serial2 or wireless bridge port
     tSerialBase* uartc; // com port
@@ -235,6 +235,8 @@ void tSerialPorts::Init(uint8_t serial_destination, uint32_t baud, uint8_t seria
         serial2 = &uartb_port;
         if (serial_destination == SERIAL_DESTINATION_COM) { // this is the ugly duck
             com = &uartd_port;
+        } else if (serial_destination == SERIAL_DESTINATION_MBRIDGE) {
+            serial = &uartd_port; // serial is unused in mbridge mode; park it on uartd so serial2 owns uartb
         }
         break;
     case SERIAL_DESTINATION2_SERIAL2:

--- a/mLRS/Common/setup.h
+++ b/mLRS/Common/setup.h
@@ -193,8 +193,8 @@ void setup_configure_metadata(void)
 #ifdef DEVICE_HAS_JRPIN5
     SetupMetaData.Tx_SerialDestination_allowed_mask |= 0b10000; // add mbridge
 #endif
-#if !(defined STM32G4 && defined USE_SERIAL && (defined USE_WIRELESS_BRIDGE || defined USE_SERIAL2))
-    SetupMetaData.Tx_SerialDestination2_allowed_mask = 0; // only for devices with fast processor and two serial ports
+#if !((defined STM32G4 || defined ESP32) && defined USE_SERIAL && defined USE_SERIAL2)
+    SetupMetaData.Tx_SerialDestination2_allowed_mask = 0; // only for devices with a fast processor and two serial ports
 #endif
 
     // Tx Buzzer: ""off,LP,rxLQ"
@@ -485,7 +485,6 @@ void setup_sanitize_config(uint8_t config_id)
     SANITIZE(Tx[config_id].SerialBaudrate2, SERIAL_BAUDRATE_NUM, SERIAL_BAUDRATE_115200, SERIAL_BAUDRATE_115200);
 
     SANITIZE(Tx[config_id].ChannelOrder, CHANNEL_ORDER_NUM, SETUP_TX_CHANNEL_ORDER, CHANNEL_ORDER_AETR);
-    SANITIZE(Tx[config_id].ChannelOrder, CHANNEL_ORDER_NUM, SETUP_TX_CHANNEL_ORDER, CHANNEL_ORDER_AETR);
 
     SANITIZE(Tx[config_id].SendRadioStatus, TX_SEND_RADIO_STATUS_NUM, SETUP_TX_SEND_RADIO_STATUS, TX_SEND_RADIO_STATUS_OFF);
     SANITIZE(Tx[config_id].MavlinkComponent, TX_MAVLINK_COMPONENT_NUM, SETUP_TX_MAV_COMPONENT, TX_MAVLINK_COMPONENT_OFF);
@@ -513,13 +512,14 @@ void setup_sanitize_config(uint8_t config_id)
         }
     }
 
-    // device cannot use same serial for both SerialDestination and SerialDestination2 !
+    // device cannot use same physical UART for both SerialDestination and SerialDestination2 !
+    // SERIAL is on uartB; WIRELESS_BRIDGE and SERIAL2 are both on uartD
     if ((  (Setup.Tx[config_id].SerialDestination == SERIAL_DESTINATION_SERIAL) &&
            (Setup.Tx[config_id].SerialDestination2 == SERIAL_DESTINATION2_SERIAL)  ) ||
-        (  (Setup.Tx[config_id].SerialDestination == SERIAL_DESTINATION_WIRELESS_BRIDGE) &&
-           (Setup.Tx[config_id].SerialDestination2 == SERIAL_DESTINATION2_WIRELESS_BRIDGE) ) ||
-        (  (Setup.Tx[config_id].SerialDestination == SERIAL_DESTINATION_SERIAL2) &&
-           (Setup.Tx[config_id].SerialDestination2 == SERIAL_DESTINATION2_SERIAL2) )){
+        (  (Setup.Tx[config_id].SerialDestination == SERIAL_DESTINATION_WIRELESS_BRIDGE ||
+            Setup.Tx[config_id].SerialDestination == SERIAL_DESTINATION_SERIAL2) &&
+           (Setup.Tx[config_id].SerialDestination2 == SERIAL_DESTINATION2_WIRELESS_BRIDGE ||
+            Setup.Tx[config_id].SerialDestination2 == SERIAL_DESTINATION2_SERIAL2) )){
         Setup.Tx[config_id].SerialDestination2 = SERIAL_DESTINATION2_NONE;
     }
 

--- a/mLRS/Common/theory_of_operation.h
+++ b/mLRS/Common/theory_of_operation.h
@@ -135,10 +135,9 @@ The assignment is done in tSerialPorts::Init():
   "com"           uartC/usb       uartB           (serial and com swapped)
   "mbridge"       uartB           uartC/usb       (serial data is routed over JR pin5, not uartB)
 
-In addition, jrpin5serial is assigned in tPin5BridgeBase::Init() and is used for ESP
-passthrough flashing on boards with DEVICE_HAS_ESP_WIFI_BRIDGE_W_PASSTHRU_VIA_JRPIN5. It is
-nullptr if the pin5 bridge was not initialized (e.g. ChannelsSource = none), and consumers
-must null-guard it.
+In addition, jrpin5serial is assigned in init_hw() (right after serials.Init()) and is used for
+ESP passthrough flashing on boards with DEVICE_HAS_ESP_WIFI_BRIDGE_W_PASSTHRU_VIA_JRPIN5. On
+boards without that feature it stays nullptr, so consumers must null-guard it.
 
 Two boot-time button overrides exist:
 

--- a/mLRS/CommonTx/cli.h
+++ b/mLRS/CommonTx/cli.h
@@ -94,9 +94,41 @@ uint8_t nr, n;
 
 
 // helper, returns allowed mask for LIST
+// The two Tx serial destination parameters share physical UARTs (serial = uartB,
+// wbridge/serial2 = uartD), so the UART already claimed by one is removed dynamically from the
+// other's mask. This single chokepoint keeps CLI, OLED and the over-link Lua/configurator
+// consistent (set-validation, listing, OLED scrolling and the mBridge param messages all use it).
 uint16_t param_get_allowed_mask(uint8_t param_idx)
 {
-    return (SetupParameter[param_idx].allowed_mask_ptr) ? *(SetupParameter[param_idx].allowed_mask_ptr) : UINT16_MAX;
+    uint16_t* const allowed_mask_ptr = SetupParameter[param_idx].allowed_mask_ptr;
+    if (allowed_mask_ptr == nullptr) return UINT16_MAX;
+
+    uint16_t allowed_mask = *allowed_mask_ptr;
+
+    if (allowed_mask_ptr == &SetupMetaData.Tx_SerialDestination2_allowed_mask) {
+        switch (Setup.Tx[Config.ConfigId].SerialDestination) {
+        case SERIAL_DESTINATION_SERIAL: // uartB
+            allowed_mask &= ~(1 << SERIAL_DESTINATION2_SERIAL);
+            break;
+        case SERIAL_DESTINATION_WIRELESS_BRIDGE: // uartD
+        case SERIAL_DESTINATION_SERIAL2: // uartD
+            allowed_mask &= ~((1 << SERIAL_DESTINATION2_WIRELESS_BRIDGE) | (1 << SERIAL_DESTINATION2_SERIAL2));
+            break;
+        }
+    } else
+    if (allowed_mask_ptr == &SetupMetaData.Tx_SerialDestination_allowed_mask) {
+        switch (Setup.Tx[Config.ConfigId].SerialDestination2) {
+        case SERIAL_DESTINATION2_SERIAL: // uartB
+            allowed_mask &= ~(1 << SERIAL_DESTINATION_SERIAL);
+            break;
+        case SERIAL_DESTINATION2_WIRELESS_BRIDGE: // uartD
+        case SERIAL_DESTINATION2_SERIAL2: // uartD
+            allowed_mask &= ~((1 << SERIAL_DESTINATION_WIRELESS_BRIDGE) | (1 << SERIAL_DESTINATION_SERIAL2));
+            break;
+        }
+    }
+
+    return allowed_mask;
 }
 
 

--- a/mLRS/CommonTx/esp.h
+++ b/mLRS/CommonTx/esp.h
@@ -47,10 +47,12 @@
 //-------------------------------------------------------
 
 // called in init_hw() to reset ESP early on, so it is hopefully booted when we attempt auto configure
-void esp_enable(uint8_t serial_destination)
+// the bridge can be selected on either serial destination, so check both
+void esp_enable(uint8_t serial_destination, uint8_t serial_destination2)
 {
 #ifdef USE_ESP_WIFI_BRIDGE_RST_GPIO0
-    if (serial_destination == SERIAL_DESTINATION_WIRELESS_BRIDGE) {  // enable/disable ESP
+    if (serial_destination == SERIAL_DESTINATION_WIRELESS_BRIDGE ||
+        serial_destination2 == SERIAL_DESTINATION2_WIRELESS_BRIDGE) {  // enable/disable ESP
         esp_gpio0_high(); esp_reset_high();
     } else {
         esp_reset_low(); // hold it in reset, should be already so but ensure it
@@ -203,7 +205,8 @@ void tTxEspWifiBridge::Init(
 #ifdef USE_ESP_WIFI_BRIDGE_CONFIGURE
     // only auto-configure when the bridge is the selected; otherwise esp_enable() holds the
     // ESP in reset and run_configure() would spin through every baud rate until timeout (ca 2 sec wasted at boot)
-    if (tx_setup->SerialDestination == SERIAL_DESTINATION_WIRELESS_BRIDGE) { run_configure(); }
+    if (tx_setup->SerialDestination == SERIAL_DESTINATION_WIRELESS_BRIDGE ||
+        tx_setup->SerialDestination2 == SERIAL_DESTINATION2_WIRELESS_BRIDGE) { run_configure(); }
 #endif
 }
 

--- a/mLRS/CommonTx/hc04.h
+++ b/mLRS/CommonTx/hc04.h
@@ -72,7 +72,8 @@ void tTxHc04Bridge::Init(tSerialPorts* const _serialports, tTxSetup* const _tx_s
     ser_baud = 115200; // it is always 115200
 
     // only auto-configure when the HC04 is selected (no wasted time at boot if not used)
-    if (_tx_setup->SerialDestination == SERIAL_DESTINATION_WIRELESS_BRIDGE) { run_configure(); }
+    if (_tx_setup->SerialDestination == SERIAL_DESTINATION_WIRELESS_BRIDGE ||
+        _tx_setup->SerialDestination2 == SERIAL_DESTINATION2_WIRELESS_BRIDGE) { run_configure(); }
 }
 
 

--- a/mLRS/CommonTx/mavlink_interface_tx.h
+++ b/mLRS/CommonTx/mavlink_interface_tx.h
@@ -150,8 +150,8 @@ class tTxMavlink
 void tTxMavlink::Init(tSerialPorts* const _serialports, tSerialBase* const _mbridge)
 {
     // if ChannelsSource = MBRIDGE:
-    //   SerialDestination = SERIAL or SERIAL2 => router with ser = mbridge & ser2 = serial/serial2
-    //   SerialDestination = MBRIDGE           => no router, only ser = mbridge (ser2 = null)
+    //   SerialDestination = SERIAL/SERIAL2/WBRIDGE/COM => router with ser = serial & ser2 = mbridge
+    //   SerialDestination = MBRIDGE                    => no router, only ser = mbridge (ser2 = null)
     // => ser2 != nullptr indicates that router is to be used
     //
     // 2\1      | SERIAL         | WBRIDGE/SERIAL2 | COM            | MBRIDGE

--- a/mLRS/CommonTx/mbridge_interface.h
+++ b/mLRS/CommonTx/mbridge_interface.h
@@ -767,11 +767,7 @@ void mbridge_send_ParamItem(void)
             strbufstrcpy(item2.unit_6, SetupParameter[param_idx].unit, 6);
             break;
         case SETUP_PARAM_TYPE_LIST:
-            if (SetupParameter[param_idx].allowed_mask_ptr != nullptr) {
-                item2.allowed_mask = *SetupParameter[param_idx].allowed_mask_ptr;
-            } else {
-                item2.allowed_mask = UINT16_MAX;
-            }
+            item2.allowed_mask = param_get_allowed_mask(param_idx); // helper handles nullptr (-> UINT16_MAX) and dynamic narrowing
             strbufstrcpy(item2.options_21, param_optstr, 21);
             if (strlen(param_optstr) >= 21) param_itemtype_to_send = MB_PARAM_ITEM3; // we need to send a 3rd ParamItem
             break;

--- a/mLRS/CommonTx/mlrs-tx.cpp
+++ b/mLRS/CommonTx/mlrs-tx.cpp
@@ -273,7 +273,7 @@ void init_hw(void)
 
     setup_init();
 
-    esp_enable(Setup.Tx[Config.ConfigId].SerialDestination);
+    esp_enable(Setup.Tx[Config.ConfigId].SerialDestination, Setup.Tx[Config.ConfigId].SerialDestination2);
     serials.Init(Setup.Tx[Config.ConfigId].SerialDestination, Config.SerialBaudrate, Setup.Tx[Config.ConfigId].SerialDestination2, Config.SerialBaudrate2);
 #ifdef DEVICE_HAS_ESP_WIFI_BRIDGE_W_PASSTHRU_VIA_JRPIN5
     serials.jrpin5serial = &jrpin5serial; // TODO: at some point we should make it a proper class in common.h


### PR DESCRIPTION
Enable TxSerDest2 on ESP32
Filter TxSerDest/TxSerDest2 lists based on setting of other

Remove duplicated ChannelOrder SANITIZE line 
Catch a Dest1/Dest2 conflict when one is wbridge and the other is serial2, since both share uartD

Fix TxSerDest2=serial when TxSerDest=mbridge by parking the unused serial on uartD so serial2 owns uartB
Fix bridge being held in reset when TxSerDest2=wbridge and enable autoconfig as well

Various comment updates
