### PR TITLE
Align INAV CRSF flight mode field with INAV's own crsfFrameFlightMode()

### DIFF
--- a/mLRS/Common/protocols/msp_protocol.h
+++ b/mLRS/Common/protocols/msp_protocol.h
@@ -337,6 +337,7 @@ typedef enum {
 typedef enum {
     INAV_ARMING_FLAGS_ARMED           = (1 << 2),
     INAV_ARMING_FLAGS_WAS_EVER_ARMED  = (1 << 3),
+    INAV_ARMING_FLAGS_ARMING_DISABLED = 0xFFFFFFC0, // all ARMING_DISABLED_ flags, bits 6 and up
 } INAV_ARMING_FLAGS_ENUM;
 
 
@@ -564,21 +565,22 @@ const tMspBoxArray inavBoxes[INAV_BOXES_COUNT] = {
 
 void inav_flight_mode_str5(char* const s, uint32_t flight_mode, uint32_t arming_flags)
 {
-    if ((arming_flags & ((uint32_t)1 << INAV_ARMING_FLAGS_ARMED)) != 0) { // some arming flags are raised
-        strcpy(s, "!ERR");
+    // follow INAV's static void crsfFrameFlightMode()
+    // https://github.com/iNavFlight/inav/blob/master/src/main/telemetry/crsf.c
+    // we don't do "WAIT", "HRST", "LAND", "GEO", "WRTH", "LOTR"
+
+    if (!(arming_flags & INAV_ARMING_FLAGS_ARMED)) { // disarmed
+        if (arming_flags & INAV_ARMING_FLAGS_ARMING_DISABLED) {
+            strcpy(s, "!ERR");
+        } else {
+            strcpy(s, "OK");
+        }
         return;
     }
 
     #define MSP_FLIGHT_MODE(fm) (flight_mode & ((uint32_t)1 << (fm)))
 
-    // follow INAV's static void crsfFrameFlightMode()
-    // https://github.com/iNavFlight/inav/blob/master/src/main/telemetry/crsf.c#L317-L374
-    // we don't do "HRST" and "LAND"
-    if (MSP_FLIGHT_MODE(INAV_FLIGHT_MODES_AIR_MODE)) {
-        strcpy(s, "AIR"); // not shown in OSD
-    } else {
-        strcpy(s, "ACRO");
-    }
+    strcpy(s, "ACRO");
 
     if (MSP_FLIGHT_MODE(INAV_FLIGHT_MODES_FAILSAFE)) {
         strcpy(s, "!FS!");
@@ -604,10 +606,6 @@ void inav_flight_mode_str5(char* const s, uint32_t flight_mode, uint32_t arming_
         strcpy(s, "HOR");
     } else if (MSP_FLIGHT_MODE(INAV_FLIGHT_MODES_ANGLE_HOLD)) {
         strcpy(s, "ANGH");
-    }
-
-    if (!MSP_FLIGHT_MODE(INAV_FLIGHT_MODES_ARM)) {
-        strcat(s, "*");
     }
 }
 


### PR DESCRIPTION
The FM field sent to the radio was an accidental mix of Betaflight and INAV schemes, dating back to when MSP support was first added. The old INAV telemetry widget accepted it, but current versions (after the CRSF handling rework) no longer do.

The supported mode set is unchanged, only the presentation now matches what INAV itself sends via CRSF:

- disarmed: `OK`, or `!ERR` when arming is disabled (any `ARMING_DISABLED_` flag)
- armed: `ACRO` base plus the existing mode chain (`!FS!`, `MANU`, `TURT`, `RTH`, `HOLD`, `CRUZ`, `CRSH`, `WP`, `AH`, `ANGL`, `HOR`, `ANGH`)
- removed the `AIR` string and the `*` disarmed suffix, neither of which INAV sends

This also fixes a bug in the armed check: `1 << INAV_ARMING_FLAGS_ARMED` shifted an already-shifted mask, so it actually tested the HITL simulator bit and `!ERR` practically never triggered. Armed state now comes from the armingFlags ARMED bit instead of the ARM box, matching `ARMING_FLAG(ARMED)`.

Modes that cannot be derived from MSP box data (`WAIT`, `HRST`, `LAND`, `GEO`, `WRTH`, `LOTR`) remain unsupported, as before.

Bench tested against INAV 9.1.0 with the current INAV telemetry widget on EdgeTX (mR900-30 tx module).