### PR TITLE
MSP: use BOXIDS instead of BOXNAMES for INAV flight mode detection

### DIFF
--- a/mLRS/CommonRx/msp_interface_rx.h
+++ b/mLRS/CommonRx/msp_interface_rx.h
@@ -78,7 +78,7 @@ class tRxMsp
     uint32_t tick_tlast_ms;
 
     #define MSP_TELM_COUNT  6
-    #define MSP_TELM_BOXNAMES_ID  5
+    #define MSP_TELM_BOXIDS_ID  5
 
     const uint16_t telm_function[MSP_TELM_COUNT] = {
         MSP2_INAV_STATUS,
@@ -86,7 +86,7 @@ class tRxMsp
         MSP2_INAV_ANALOG,
         MSP_RAW_GPS,
         MSP_ALTITUDE,
-        MSP_BOXNAMES, // MSP_BOXIDS, seems to hold incorrect flags ??
+        MSP_BOXIDS, // permanent box ids, stable across INAV versions, much smaller reply than MSP_BOXNAMES
     };
 
     const uint8_t telm_freq[MSP_TELM_COUNT] = {
@@ -95,7 +95,7 @@ class tRxMsp
         1,  // 1 Hz = 10*100 ms, MSP_INAV_ANALOG
         2,  // 2 Hz = 5*100 ms, MSP_RAW_GPS
         2,  // 2 Hz = 5*100 ms, MSP_ALTITUDE
-        1,  // this is set to zero once MSP_BOXNAMES has been gotten once, disables request
+        1,  // this is set to zero once MSP_BOXIDS has been gotten once, disables request
     };
 
     typedef struct {
@@ -107,7 +107,7 @@ class tRxMsp
 
     void telm_set_default_rate(uint8_t n) { telm[n].rate = (telm_freq[n] > 0) ? 10 / telm_freq[n] : 0; }
 
-    uint8_t inav_flight_modes_box_mode_flags[INAV_FLIGHT_MODES_COUNT]; // store info from MSP_BOXNAMES
+    uint8_t inav_flight_modes_box_mode_flags[INAV_FLIGHT_MODES_COUNT]; // store info from MSP_BOXIDS
 
     // to handle command MSP_REBOOT
     uint32_t reboot_activate_ms;
@@ -181,7 +181,7 @@ void tRxMsp::Do(void)
 {
     if (!connected()) {
         fifo_link_out.Flush();
-        telm_set_default_rate(MSP_TELM_BOXNAMES_ID);
+        telm_set_default_rate(MSP_TELM_BOXIDS_ID);
     }
 
     if (!SERIAL_LINK_MODE_IS_MSP(Setup.Rx.SerialLinkMode)) return;
@@ -256,10 +256,10 @@ void tRxMsp::parse_serial_in_link_out(void)
                 bool send = true;
 
                 if (msp_msg_ser_in.type == MSP_TYPE_RESPONSE) { // this is a response from the FC
-                    if (msp_msg_ser_in.function == MSP2_INAV_STATUS && telm[MSP_TELM_BOXNAMES_ID].rate == 0) {
+                    if (msp_msg_ser_in.function == MSP2_INAV_STATUS && telm[MSP_TELM_BOXIDS_ID].rate == 0) {
                         // when we get a MSP2_INAV_STATUS
                         // send out our home-brewed MSPX_STATUS message in addition
-                        // do only after we have seen MSP_BOXNAMES
+                        // do only after we have seen MSP_BOXIDS
                         // is being send before original message
                         uint32_t flight_mode_flags = 0;
                         uint8_t* boxflags = ((tMspInavStatus*)(msp_msg_ser_in.payload))->msp_box_mode_flags;
@@ -278,15 +278,31 @@ void tRxMsp::parse_serial_in_link_out(void)
                             sizeof(flight_mode_flags));
                         fifo_link_out.PutBuf(_buf, len);
                     }
+                    if (msp_msg_ser_in.function == MSP_BOXIDS) {
+                        // build inav_flight_modes_box_mode_flags[] from the permanent ids
+                        // the position in the reply is the box's bit position in MSP2_INAV_STATUS's box mode flags
+                        memset(inav_flight_modes_box_mode_flags, 255, INAV_FLIGHT_MODES_COUNT); // 255 = is empty
+                        for (uint16_t i = 0; i < msp_msg_ser_in.len; i++) {
+                            for (uint8_t n = 0; n < INAV_BOXES_COUNT; n++) {
+                                if (inavBoxes[n].permanentId == msp_msg_ser_in.payload[i]) {
+                                    if (inavBoxes[n].flightMode < INAV_FLIGHT_MODES_COUNT) { // is a flight mode we want to record in MSPX_STATUS
+                                        inav_flight_modes_box_mode_flags[inavBoxes[n].flightMode] = i;
+                                    }
+                                    break; // found, no need to look further
+                                }
+                            }
+                        }
+
+                        telm[MSP_TELM_BOXIDS_ID].rate = 0; // disable MSP_BOXIDS requesting
+                    }
                     if (msp_msg_ser_in.function == MSP_BOXNAMES) {
-                        // compress, and also get inav_flight_modes_box_mode_flags[]
+                        // compress, is requested by a gcs, we don't request it ourselves
                         uint8_t new_payload[512]; // MSP_BOXNAMES is 340 bytes in INAV 7.1, up to 646 in 9.1 counting chars in boxes[], hopefully compressed though
                         uint16_t new_len = 0;
+                        uint8_t box_mode_flags_unused[INAV_FLIGHT_MODES_COUNT];
                         mspX_boxnames_payload_compress(
                             new_payload, &new_len, msp_msg_ser_in.payload, msp_msg_ser_in.len,
-                            inav_flight_modes_box_mode_flags);
-
-                        telm[MSP_TELM_BOXNAMES_ID].rate = 0; // disable MSP_BOXNAMES requesting
+                            box_mode_flags_unused);
 
                         uint16_t len = msp_generate_v2_frame_bufX(
                             _buf,


### PR DESCRIPTION
While digging into the reports of missing flight modes on the radio I found that the rx never gets its box table on many INAV setups: INAV refuses to answer MSP_BOXNAMES when the reply does not fit its MSP output buffer, which is easily the case on INAV 8/9 once GPS and nav modes are enabled (49 active boxes = 543 bytes on my bench). Without BOXNAMES the rx never sends MSPX_STATUS and the FM field stays dead. That buffer limit is an INAV bug and I will report it there, but it made me question why we depend on BOXNAMES at all.

This switches the rx-internal box fetching to MSP_BOXIDS. The inavBoxes[] table gets a permanentId column (from fc_msp_box.c) and the rx builds inav_flight_modes_box_mode_flags[] from the BOXIDS reply, position in the reply = bit position in MSP2_INAV_STATUS, same as before with the names.

Why I think BOXIDS is the better fit, independent of the INAV bug:

- BOXNAMES never was the version-independent source of truth it looks like. We match the names against our own baked-in table anyway, unknown names are dropped. The only dynamic information we actually need is which box sits on which bit position, and BOXIDS delivers exactly that.
- permanentIds are frozen by INAV by contract, that is what they exist for. Names have been renamed in the past and will be again.
- The reply is ~50 bytes instead of 340-650, so no compression needed on the internal path and no big buffer on the rx stack.
- The fetch pattern is unchanged: requested once after connect, then disabled, re-armed on disconnect, exactly like BOXNAMES before. The mapping is just cleared before it is rebuilt, so a changed FC config cannot leave stale entries behind after a reconnect.
- This is also what the rest of the ecosystem does: INAV Configurator only requests BOXIDS and resolves names from its own permanentId table (BOXNAMES does not appear in their code at all), Ardudeck does BOXIDS + static lookup for INAV with the explicit comment that the BOXNAMES reply is too large, and mwptools works fine from BOXIDS alone and only logs an error if BOXNAMES fails.

The BOXNAMES passthrough for a GCS on the ground is untouched, requests are still forwarded and the reply still gets compressed over the link, mwptools keeps working. Only the flight mode mapping no longer depends on it.

Bench tested against INAV 9.1.0 (Matek F765, mR900-22 rx, mR900-30 tx module): with GPS enabled BOXNAMES still fails FC-side but flight modes now show correctly via BOXIDS. Draft for now, I am still testing against other INAV versions and in the simulator.
