### PR TITLE
Target Insensitive in Tool Scripts

### DIFF
--- a/tools/run_flash_stm32_linux.py
+++ b/tools/run_flash_stm32_linux.py
@@ -46,10 +46,9 @@ def find_firmware_hex(target):
     # .hex files in tools/build/firmware/ whose name contains the target substring (case insensitive)
     if not os.path.isdir(MLRS_FIRMWARE_DIR):
         return []
-    target = target.lower()
     hexes = []
     for path in sorted(glob.glob(os.path.join(MLRS_FIRMWARE_DIR, '*.hex'))):
-        if target in os.path.basename(path).lower():
+        if target.lower() in os.path.basename(path).lower():
             hexes.append(path)
     return hexes
 

--- a/tools/run_flash_stm32_linux.py
+++ b/tools/run_flash_stm32_linux.py
@@ -43,12 +43,13 @@ def build_target(target, defines):
 
 
 def find_firmware_hex(target):
-    # .hex files in tools/build/firmware/ whose name contains the target substring
+    # .hex files in tools/build/firmware/ whose name contains the target substring (case insensitive)
     if not os.path.isdir(MLRS_FIRMWARE_DIR):
         return []
+    target = target.lower()
     hexes = []
     for path in sorted(glob.glob(os.path.join(MLRS_FIRMWARE_DIR, '*.hex'))):
-        if target in os.path.basename(path):
+        if target in os.path.basename(path).lower():
             hexes.append(path)
     return hexes
 
@@ -126,7 +127,7 @@ FLASH_METHODS = {
 def main():
     parser = argparse.ArgumentParser(description='Build an STM32 mLRS target and flash it to the board.')
     parser.add_argument('-t', '--target', required=True,
-        help='target name (substring) to build and flash, e.g. tx-matek-mr24-30-g431kb')
+        help='target name (substring, case insensitive) to build and flash, e.g. tx-matek-mr24-30-g431kb')
     parser.add_argument('-m', '--method', choices=sorted(FLASH_METHODS.keys()), default='dfu',
         help='flashing method (default: dfu)')
     parser.add_argument('-d', '--define', action='append', default=[], metavar='DEFINE',

--- a/tools/run_make_esp_firmwares.py
+++ b/tools/run_make_esp_firmwares.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
         cmd_pos += 1
         if cmd == '--target' or cmd == '-t' or cmd == '-T':
             if sys.argv[cmd_pos+1] != '':
-                cmdline_target = sys.argv[cmd_pos+1]
+                cmdline_target = sys.argv[cmd_pos+1].lower() # target matching is case insensitive
         if cmd == '--define' or cmd == '-d' or cmd == '-D':
             if sys.argv[cmd_pos+1] != '':
                 cmdline_D_list.append(sys.argv[cmd_pos+1])

--- a/tools/run_make_firmwares.py
+++ b/tools/run_make_firmwares.py
@@ -1243,7 +1243,7 @@ if __name__ == "__main__":
         cmd_pos += 1
         if cmd == '--target' or cmd == '-t' or cmd == '-T':
             if sys.argv[cmd_pos+1] != '':
-                cmdline_target = sys.argv[cmd_pos+1]
+                cmdline_target = sys.argv[cmd_pos+1].lower() # target matching is case insensitive
         if cmd == '--define' or cmd == '-d' or cmd == '-D':
             if sys.argv[cmd_pos+1] != '':
                 cmdline_D_list.append(sys.argv[cmd_pos+1])
@@ -1268,9 +1268,10 @@ if __name__ == "__main__":
 
     target_cnt = 0
     for target in targetlist:
+        target_name = target.target.lower()
         if ((cmdline_target == '') or
-            (cmdline_target[0] != '!' and cmdline_target in target.target) or
-            (cmdline_target[0] == '!' and not cmdline_target[1:] in target.target)):
+            (cmdline_target[0] != '!' and cmdline_target in target_name) or
+            (cmdline_target[0] == '!' and not cmdline_target[1:] in target_name)):
             mlrs_build_target(target, cmdline_D_list)
             target_cnt +=1
 

--- a/tools/run_make_firmwares.py
+++ b/tools/run_make_firmwares.py
@@ -1268,10 +1268,9 @@ if __name__ == "__main__":
 
     target_cnt = 0
     for target in targetlist:
-        target_name = target.target.lower()
         if ((cmdline_target == '') or
-            (cmdline_target[0] != '!' and cmdline_target in target_name) or
-            (cmdline_target[0] == '!' and not cmdline_target[1:] in target_name)):
+            (cmdline_target[0] != '!' and cmdline_target in target.target.lower()) or
+            (cmdline_target[0] == '!' and not cmdline_target[1:] in target.target.lower())):
             mlrs_build_target(target, cmdline_D_list)
             target_cnt +=1
 


### PR DESCRIPTION
Since the targets seem a bit inconsistent IMO and I always forget, just remove case sensitivity for the target argument in the tool scripts.

Examples:

- R9M (with caps)
- Wio (with caps)
- frsky (without caps)