### PR TITLE
Fix Hiding Warning

### DIFF
--- a/mLRS/CommonTx/mbridge_interface.h
+++ b/mLRS/CommonTx/mbridge_interface.h
@@ -38,6 +38,7 @@ typedef enum {
 class tMBridge : public tPin5BridgeBase, public tSerialBase
 {
   public:
+    using tSerialBase::Init; // would be hidden by Init(bool,bool) otherwise
     void Init(bool enable_flag, bool crsf_emulation_flag);
     bool ChannelsUpdated(tRcData* const rc);
     bool TelemetryUpdate(uint8_t* const task);
@@ -875,6 +876,7 @@ void mbridge_send_cmd(uint8_t cmd)
 class tMBridge : public tSerialBase
 {
   public:
+    using tSerialBase::Init; // would be hidden by Init(bool,bool) otherwise
     void Init(bool enable_flag, bool crsf_emulation_flag) {}
     void TelemetryStart(void) {}
     void TelemetryTick_ms(void) {}

--- a/mLRS/CommonTx/sx_serial_interface_tx.h
+++ b/mLRS/CommonTx/sx_serial_interface_tx.h
@@ -22,6 +22,7 @@ extern tTxMsp msp;
 class tTxSxSerial : public tSerialBase
 {
   public:
+    using tSerialBase::Init; // would be hidden by Init(tSerialBase*) otherwise
     void Init(tSerialBase* const _mbridge);
 
     bool available(void) override;


### PR DESCRIPTION
To address `warning: 'virtual void tSerialBase::Init()' was hidden [-Woverloaded-virtual=]` recent compilers (e.g GCC 15.3.1) show.

