### PR TITLE
Add BAYCKRC UR500 & UR1000 (ESP32-C3 + LR1121) as Tx module targets

### DIFF
--- a/mLRS/Common/hal/esp/esp-device_conf.h
+++ b/mLRS/Common/hal/esp/esp-device_conf.h
@@ -226,6 +226,15 @@
   #define FREQUENCY_BAND_915_MHZ_FCC
 #endif
 
+#ifdef TX_BAYCK_UR500_ESP32C3 // receiver used as Tx module
+  #define DEVICE_NAME "BAYCK UR500"
+  #define DEVICE_IS_TRANSMITTER
+  #define DEVICE_HAS_LR11xx
+  #define FREQUENCY_BAND_2P4_GHZ
+  #define FREQUENCY_BAND_868_MHZ
+  #define FREQUENCY_BAND_915_MHZ_FCC
+#endif
+
 
 //-- ELRS Internal Tx Modules
 

--- a/mLRS/Common/hal/esp/esp-device_conf.h
+++ b/mLRS/Common/hal/esp/esp-device_conf.h
@@ -235,6 +235,15 @@
   #define FREQUENCY_BAND_915_MHZ_FCC
 #endif
 
+#ifdef TX_BAYCK_UR1000_ESP32C3 // receiver used as Tx module
+  #define DEVICE_NAME "BAYCK UR1000"
+  #define DEVICE_IS_TRANSMITTER
+  #define DEVICE_HAS_LR11xx
+  #define FREQUENCY_BAND_2P4_GHZ
+  #define FREQUENCY_BAND_868_MHZ
+  #define FREQUENCY_BAND_915_MHZ_FCC
+#endif
+
 
 //-- ELRS Internal Tx Modules
 

--- a/mLRS/Common/hal/esp/esp-hal.h
+++ b/mLRS/Common/hal/esp/esp-hal.h
@@ -163,6 +163,10 @@
 #include "tx-hal-bayck-ur500-esp32c3.h"
 #endif
 
+#ifdef TX_BAYCK_UR1000_ESP32C3
+#include "tx-hal-bayck-ur1000-esp32c3.h"
+#endif
+
 #ifdef TX_ELRS_FLYSKY_INTERNAL_PA01_2400_ESP32S3
 #include "tx-hal-flysky-int-pa01-2400-esp32s3.h"
 #endif

--- a/mLRS/Common/hal/esp/esp-hal.h
+++ b/mLRS/Common/hal/esp/esp-hal.h
@@ -159,6 +159,10 @@
 #include "tx-hal-radiomaster-nomad-esp32.h"
 #endif
 
+#ifdef TX_BAYCK_UR500_ESP32C3
+#include "tx-hal-bayck-ur500-esp32c3.h"
+#endif
+
 #ifdef TX_ELRS_FLYSKY_INTERNAL_PA01_2400_ESP32S3
 #include "tx-hal-flysky-int-pa01-2400-esp32s3.h"
 #endif

--- a/mLRS/Common/hal/esp/tx-hal-bayck-ur1000-esp32c3.h
+++ b/mLRS/Common/hal/esp/tx-hal-bayck-ur1000-esp32c3.h
@@ -1,0 +1,177 @@
+//*******************************************************
+// Copyright (c) MLRS project
+// GPL3
+// https://www.gnu.org/licenses/gpl-3.0.de.html
+//*******************************************************
+// hal
+//********************************************************
+
+/*
+  BAYCKRC UR1000 receiver flashed as Tx module (ESP32-C3 + LR1121)
+
+  Wiring for use as JR bay Tx module:
+  - radio module bay pin 5 (CRSF signal) -> UR1000 GPIO18 (serial1 rx pad)
+  - radio module bay pin 1 (GND)         -> UR1000 GND
+  - power: feed 5V to UR1000 VCC pad (check board markings!)
+
+  Pin source: ExpressLRS Targets ur1000 overlay on "Generic C3 LR1121.json"
+*/
+
+//-------------------------------------------------------
+// ESP32-C3, BAYCKRC UR1000 as Tx Module, LR1121 2400 & 900
+//-------------------------------------------------------
+
+#define DEVICE_HAS_JRPIN5
+#define DEVICE_HAS_SINGLE_LED_RGB
+#define DEVICE_HAS_NO_DEBUG
+#define DEVICE_HAS_NO_COM
+
+
+//-- UARTS
+// UARTB = serial port (USB-serial bridge on GPIO21/20)
+// UART  = JR bay pin5, CRSF from radio (Serial1, half-duplex on GPIO18)
+// UARTF = debug port (not used)
+
+#define UARTB_USE_SERIAL
+#define UARTB_BAUD                TX_SERIAL_BAUDRATE
+#define UARTB_USE_TX_IO           IO_P21
+#define UARTB_USE_RX_IO           IO_P20
+#define UARTB_TXBUFSIZE           TX_SERIAL_TXBUFSIZE
+#define UARTB_RXBUFSIZE           TX_SERIAL_RXBUFSIZE
+
+#define UART_USE_SERIAL1 // JR bay pin5, half-duplex
+#define UART_BAUD                 400000
+#define UART_USE_TX_IO            IO_P18
+#define UART_USE_RX_IO            IO_P18
+#define UART_TXBUFSIZE            0  // TX FIFO = 128
+#define UART_RXBUFSIZE            0  // RX FIFO = 128 + 1
+
+
+//-- SX1: LR11xx & SPI
+// same pinout as rx-hal-generic-c3-lr1121-esp32c3.h (identical hardware)
+
+#define SPI_CS_IO                 IO_P7
+#define SPI_MISO                  IO_P5
+#define SPI_MOSI                  IO_P4
+#define SPI_SCK                   IO_P6
+#define SPI_FREQUENCY             16000000L  // 16 MHz max per datasheet
+#define SX_RESET                  IO_P2
+#define SX_DIO                    IO_P1
+#define SX_BUSY                   IO_P3
+
+#define SX_USE_REGULATOR_MODE_DCDC
+
+IRQHANDLER(void SX_DIO_EXTI_IRQHandler(void);)
+
+void sx_init_gpio(void)
+{
+    gpio_init(SX_RESET, IO_MODE_OUTPUT_PP_LOW);
+    gpio_init(SX_DIO, IO_MODE_INPUT_ANALOG);
+    gpio_init(SX_BUSY, IO_MODE_INPUT_ANALOG);
+}
+
+IRAM_ATTR bool sx_busy_read(void) { return (gpio_read_activehigh(SX_BUSY)) ? true : false; }
+
+IRAM_ATTR void sx_amp_transmit(void) {}
+IRAM_ATTR void sx_amp_receive(void) {}
+
+void sx_dio_init_exti_isroff(void) { detachInterrupt(SX_DIO); }
+void sx_dio_enable_exti_isr(void) { attachInterrupt(SX_DIO, SX_DIO_EXTI_IRQHandler, RISING); }
+IRAM_ATTR void sx_dio_exti_isr_clearflag(void) {}
+
+
+//-- Button
+
+#define BUTTON                    IO_P9
+
+void button_init(void)
+{
+    gpio_init(BUTTON, IO_MODE_INPUT_PU);
+}
+
+IRAM_ATTR bool button_pressed(void)
+{
+    return gpio_read_activelow(BUTTON) ? true : false;
+}
+
+
+//-- LEDs
+
+#define LED_RGB                   IO_P8
+#define LED_RGB_PIXEL_NUM         1
+#include "esp-hal-led-rgb.h"
+
+
+//-- POWER
+// power values from ExpressLRS ur1000 overlay:
+//   power_values      (2.4 GHz): [-8, -4, -1, 3]  for ELRS levels 3/4/5/6 (100/250/500/1000 mW)
+//   power_values_dual (900 MHz): [-9, -4, -1, 3]  for ELRS levels 3/4/5/6
+// board uses external PA, chip drives it via RFO (radio_rfo_hf)
+
+#include "../../setup_types.h" // needed for frequency band condition in rfpower calc
+
+#define SX_USE_LP_PA               // radio_rfo_hf option, use low power PA to drive external PA
+#define SX_USE_RFSW_CTRL  {15, 0, 4, 12, 0, 2, 0, 1} // radio_rfsw_ctrl array
+
+void lr11xx_rfpower_calc(const int8_t power_dbm, int8_t* sx_power, int8_t* actual_power_dbm, const uint8_t frequency_band)
+{
+    if (frequency_band == SX_FHSS_FREQUENCY_BAND_2P4_GHZ) {
+        if (power_dbm >= POWER_30_DBM) { // -> 30 (1000 mW, ELRS level 6)
+            *sx_power = 3;
+            *actual_power_dbm = 30;
+        } else if (power_dbm >= POWER_27_DBM) { // -> 27 (500 mW, ELRS level 5)
+            *sx_power = -1;
+            *actual_power_dbm = 27;
+        } else if (power_dbm >= POWER_24_DBM) { // -> 24 (250 mW, ELRS level 4)
+            *sx_power = -4;
+            *actual_power_dbm = 24;
+        } else if (power_dbm >= POWER_20_DBM) { // -> 20 (100 mW, ELRS level 3)
+            *sx_power = -8;
+            *actual_power_dbm = 20;
+        } else if (power_dbm >= POWER_14_DBM) { // -> 14
+            *sx_power = -14;
+            *actual_power_dbm = 14;
+        } else if (power_dbm >= POWER_10_DBM) { // -> 10
+            *sx_power = -18;
+            *actual_power_dbm = 10;
+        } else {
+            *sx_power = -20;
+            *actual_power_dbm = 3;
+        }
+    } else { // 868/915 MHz
+        if (power_dbm >= POWER_30_DBM) { // -> 30 (1000 mW, ELRS level 6)
+            *sx_power = 3;
+            *actual_power_dbm = 30;
+        } else if (power_dbm >= POWER_27_DBM) { // -> 27 (500 mW, ELRS level 5)
+            *sx_power = -1;
+            *actual_power_dbm = 27;
+        } else if (power_dbm >= POWER_24_DBM) { // -> 24 (250 mW, ELRS level 4)
+            *sx_power = -4;
+            *actual_power_dbm = 24;
+        } else if (power_dbm >= POWER_20_DBM) { // -> 20 (100 mW, ELRS level 3)
+            *sx_power = -9;
+            *actual_power_dbm = 20;
+        } else if (power_dbm >= POWER_14_DBM) { // -> 14
+            *sx_power = -14;
+            *actual_power_dbm = 14;
+        } else if (power_dbm >= POWER_10_DBM) { // -> 10
+            *sx_power = -18;
+            *actual_power_dbm = 10;
+        } else {
+            *sx_power = -20;
+            *actual_power_dbm = 3;
+        }
+    }
+}
+
+#define RFPOWER_DEFAULT           2 // index into rfpower_list array
+
+const rfpower_t rfpower_list[] = {
+    { .dbm = POWER_3_DBM, .mW = 2 },
+    { .dbm = POWER_10_DBM, .mW = 10 },
+    { .dbm = POWER_14_DBM, .mW = 25 },
+    { .dbm = POWER_20_DBM, .mW = 100 },
+    { .dbm = POWER_24_DBM, .mW = 250 },
+    { .dbm = POWER_27_DBM, .mW = 500 },
+    { .dbm = POWER_30_DBM, .mW = 1000 },
+};

--- a/mLRS/Common/hal/esp/tx-hal-bayck-ur500-esp32c3.h
+++ b/mLRS/Common/hal/esp/tx-hal-bayck-ur500-esp32c3.h
@@ -1,0 +1,170 @@
+//*******************************************************
+// Copyright (c) MLRS project
+// GPL3
+// https://www.gnu.org/licenses/gpl-3.0.de.html
+//*******************************************************
+// hal
+//********************************************************
+
+/*
+  BAYCKRC UR500 receiver flashed as Tx module (ESP32-C3 + LR1121)
+
+  Wiring for use as JR bay Tx module:
+  - radio module bay pin 5 (CRSF signal) -> UR500 GPIO18 (serial1 rx pad)
+  - radio module bay pin 1 (GND)         -> UR500 GND
+  - power: feed 5V to UR500 VCC pad (check board markings!)
+
+  Pin source: ExpressLRS Targets ur500 overlay on "Generic C3 LR1121.json"
+*/
+
+//-------------------------------------------------------
+// ESP32-C3, BAYCKRC UR500 as Tx Module, LR1121 2400 & 900
+//-------------------------------------------------------
+
+#define DEVICE_HAS_JRPIN5
+#define DEVICE_HAS_SINGLE_LED_RGB
+#define DEVICE_HAS_NO_DEBUG
+#define DEVICE_HAS_NO_COM
+
+
+//-- UARTS
+// UARTB = serial port (USB-serial bridge on GPIO21/20)
+// UART  = JR bay pin5, CRSF from radio (Serial1, half-duplex on GPIO18)
+// UARTF = debug port (not used)
+
+#define UARTB_USE_SERIAL
+#define UARTB_BAUD                TX_SERIAL_BAUDRATE
+#define UARTB_USE_TX_IO           IO_P21
+#define UARTB_USE_RX_IO           IO_P20
+#define UARTB_TXBUFSIZE           TX_SERIAL_TXBUFSIZE
+#define UARTB_RXBUFSIZE           TX_SERIAL_RXBUFSIZE
+
+#define UART_USE_SERIAL1 // JR bay pin5, half-duplex
+#define UART_BAUD                 400000
+#define UART_USE_TX_IO            IO_P18
+#define UART_USE_RX_IO            IO_P18
+#define UART_TXBUFSIZE            0  // TX FIFO = 128
+#define UART_RXBUFSIZE            0  // RX FIFO = 128 + 1
+
+
+//-- SX1: LR11xx & SPI
+// same pinout as rx-hal-generic-c3-lr1121-esp32c3.h (identical hardware)
+
+#define SPI_CS_IO                 IO_P7
+#define SPI_MISO                  IO_P5
+#define SPI_MOSI                  IO_P4
+#define SPI_SCK                   IO_P6
+#define SPI_FREQUENCY             16000000L  // 16 MHz max per datasheet
+#define SX_RESET                  IO_P2
+#define SX_DIO                    IO_P1
+#define SX_BUSY                   IO_P3
+
+#define SX_USE_REGULATOR_MODE_DCDC
+
+IRQHANDLER(void SX_DIO_EXTI_IRQHandler(void);)
+
+void sx_init_gpio(void)
+{
+    gpio_init(SX_RESET, IO_MODE_OUTPUT_PP_LOW);
+    gpio_init(SX_DIO, IO_MODE_INPUT_ANALOG);
+    gpio_init(SX_BUSY, IO_MODE_INPUT_ANALOG);
+}
+
+IRAM_ATTR bool sx_busy_read(void) { return (gpio_read_activehigh(SX_BUSY)) ? true : false; }
+
+IRAM_ATTR void sx_amp_transmit(void) {}
+IRAM_ATTR void sx_amp_receive(void) {}
+
+void sx_dio_init_exti_isroff(void) { detachInterrupt(SX_DIO); }
+void sx_dio_enable_exti_isr(void) { attachInterrupt(SX_DIO, SX_DIO_EXTI_IRQHandler, RISING); }
+IRAM_ATTR void sx_dio_exti_isr_clearflag(void) {}
+
+
+//-- Button
+
+#define BUTTON                    IO_P9
+
+void button_init(void)
+{
+    gpio_init(BUTTON, IO_MODE_INPUT_PU);
+}
+
+IRAM_ATTR bool button_pressed(void)
+{
+    return gpio_read_activelow(BUTTON) ? true : false;
+}
+
+
+//-- LEDs
+
+#define LED_RGB                   IO_P8
+#define LED_RGB_PIXEL_NUM         1
+#include "esp-hal-led-rgb.h"
+
+
+//-- POWER
+// power values from ExpressLRS ur500 overlay:
+//   power_values      (2.4 GHz): [-7, -3, 0]  for ELRS levels 3/4/5 (100/250/500 mW)
+//   power_values_dual (900 MHz): [-7, -2, 3]  for ELRS levels 3/4/5
+// board uses external PA with roughly 24-27 dB gain, chip drives it via RFO (radio_rfo_hf)
+
+#include "../../setup_types.h" // needed for frequency band condition in rfpower calc
+
+#define SX_USE_LP_PA               // radio_rfo_hf option, use low power PA to drive external PA
+#define SX_USE_RFSW_CTRL  {15, 0, 4, 12, 0, 2, 0, 1} // radio_rfsw_ctrl array
+
+void lr11xx_rfpower_calc(const int8_t power_dbm, int8_t* sx_power, int8_t* actual_power_dbm, const uint8_t frequency_band)
+{
+    if (frequency_band == SX_FHSS_FREQUENCY_BAND_2P4_GHZ) {
+        if (power_dbm >= POWER_27_DBM) { // -> 27 (500 mW, ELRS level 5)
+            *sx_power = 0;
+            *actual_power_dbm = 27;
+        } else if (power_dbm >= POWER_24_DBM) { // -> 24 (250 mW, ELRS level 4)
+            *sx_power = -3;
+            *actual_power_dbm = 24;
+        } else if (power_dbm >= POWER_20_DBM) { // -> 20 (100 mW, ELRS level 3)
+            *sx_power = -7;
+            *actual_power_dbm = 20;
+        } else if (power_dbm >= POWER_14_DBM) { // -> 14
+            *sx_power = -13;
+            *actual_power_dbm = 14;
+        } else if (power_dbm >= POWER_10_DBM) { // -> 10
+            *sx_power = -17;
+            *actual_power_dbm = 10;
+        } else {
+            *sx_power = -18;
+            *actual_power_dbm = 3;
+        }
+    } else { // 868/915 MHz
+        if (power_dbm >= POWER_27_DBM) { // -> 27 (500 mW, ELRS level 5)
+            *sx_power = 3;
+            *actual_power_dbm = 27;
+        } else if (power_dbm >= POWER_24_DBM) { // -> 24 (250 mW, ELRS level 4)
+            *sx_power = -2;
+            *actual_power_dbm = 24;
+        } else if (power_dbm >= POWER_20_DBM) { // -> 20 (100 mW, ELRS level 3)
+            *sx_power = -7;
+            *actual_power_dbm = 20;
+        } else if (power_dbm >= POWER_14_DBM) { // -> 14
+            *sx_power = -11;
+            *actual_power_dbm = 14;
+        } else if (power_dbm >= POWER_10_DBM) { // -> 10
+            *sx_power = -15;
+            *actual_power_dbm = 10;
+        } else {
+            *sx_power = -18;
+            *actual_power_dbm = 3;
+        }
+    }
+}
+
+#define RFPOWER_DEFAULT           2 // index into rfpower_list array
+
+const rfpower_t rfpower_list[] = {
+    { .dbm = POWER_3_DBM, .mW = 2 },
+    { .dbm = POWER_10_DBM, .mW = 10 },
+    { .dbm = POWER_14_DBM, .mW = 25 },
+    { .dbm = POWER_20_DBM, .mW = 100 },
+    { .dbm = POWER_24_DBM, .mW = 250 },
+    { .dbm = POWER_27_DBM, .mW = 500 },
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -449,6 +449,19 @@ build_flags =
   -D TX_BAYCK_UR500_ESP32C3
 
 
+[env:tx-bayck-ur1000]                    ; BAYCKRC UR1000 receiver used as Tx module
+extends = env_common_tx_esp32c3
+board = esp32-c3-devkitm-1
+lib_deps =
+  makuna/NeoPixelBus@^2.8.3
+build_src_filter =
+  ${env_common_tx_esp32c3.build_src_filter}
+  +<modules/sx12xx-lib/src/lr11xx.cpp>
+build_flags =
+  ${env_common_tx_esp32c3.build_flags}
+  -D TX_BAYCK_UR1000_ESP32C3
+
+
 ;-- some ELRS Tx, Internal Modules
 
 [env:tx-jumper-internal-2400]           ; good for T20 V1, T20 V2, T15, T15 Pro, T14, T-Pro S

--- a/platformio.ini
+++ b/platformio.ini
@@ -134,6 +134,10 @@ build_src_filter =
 extends = env_common_esp32
 build_src_filter = ${env_common_tx.build_src_filter}
 
+[env_common_tx_esp32c3]
+extends = env_common_esp32c3
+build_src_filter = ${env_common_tx.build_src_filter}
+
 [env_common_tx_esp32s3]
 extends = env_common_esp32s3
 build_src_filter = ${env_common_tx.build_src_filter}
@@ -430,6 +434,19 @@ build_src_filter =
 build_flags = 
   ${env_common_tx_esp32.build_flags}
   -D TX_ELRS_RADIOMASTER_NOMAD_ESP32
+
+
+[env:tx-bayck-ur500]                     ; BAYCKRC UR500 receiver used as Tx module
+extends = env_common_tx_esp32c3
+board = esp32-c3-devkitm-1
+lib_deps =
+  makuna/NeoPixelBus@^2.8.3
+build_src_filter =
+  ${env_common_tx_esp32c3.build_src_filter}
+  +<modules/sx12xx-lib/src/lr11xx.cpp>
+build_flags =
+  ${env_common_tx_esp32c3.build_flags}
+  -D TX_BAYCK_UR500_ESP32C3
 
 
 ;-- some ELRS Tx, Internal Modules


### PR DESCRIPTION
## Summary

Add support for using **BAYCKRC UR500** and **UR1000** dual-band receivers as MLRS **Tx (JR-bay) modules**.

Both boards are ESP32-C3 + LR1121 based receivers sold by BAYCKRC, sharing the same layout file ("Generic C3 LR1121.json"). They differ only in the external PA power table.

### Changes

**UR500** (commit 1):
- New HAL `tx-hal-bayck-ur500-esp32c3.h` — 3..27 dBm (2..500 mW)
- Register `TX_BAYCK_UR500_ESP32C3` in `esp-device_conf.h` and `esp-hal.h`
- Add `env_common_tx_esp32c3` and `tx-bayck-ur500` build target to `platformio.ini`

**UR1000** (commit 2):
- New HAL `tx-hal-bayck-ur1000-esp32c3.h` — 3..30 dBm (2..1000 mW)
- Register `TX_BAYCK_UR1000_ESP32C3` in `esp-device_conf.h` and `esp-hal.h`
- Add `tx-bayck-ur1000` build target to `platformio.ini`

### Pinout (identical for both, from ExpressLRS ur500/ur1000 overlay)
- LR1121 SPI: NSS=7 / MISO=5 / MOSI=4 / SCK=6 / RST=2 / DIO=1 / BUSY=3
- RGB LED=8, button=9
- JR bay pin5 (CRSF) -> GPIO18 (half-duplex, 400k)
- Serial port (MAVLink) -> GPIO20/21 (UARTB, 115200 baud default)
- RFSW_CTRL: {15, 0, 4, 12, 0, 2, 0, 1}

### Testing
- Both compile cleanly with PlatformIO (`tx-bayck-ur500`, `tx-bayck-ur1000`).
- Firmware reports device names `BAYCK UR500` / `BAYCK UR1000` (verified in built ELF).

Pre-built binaries: https://github.com/zws1023/mLRS/releases

/cc @olliw42