### PR TITLE
GCC 16 Warning Fix

### DIFF
--- a/mLRS/Common/common.h
+++ b/mLRS/Common/common.h
@@ -145,7 +145,7 @@ tUartCPort uartc_port;
 tUartDPort uartd_port;
 tUsbPort usb_port;
 
-typedef struct
+struct tSerialPorts
 {
     tSerialBase* serial; // assigned according to TxSerPort
     tSerialBase* com; // assigned according to TxSerPort
@@ -163,7 +163,7 @@ typedef struct
 #ifdef USE_COM_ON_SERIAL
     tSerialBase* ser_or_com_set_to_com(void);
 #endif
-} tSerialPorts;
+};
 
 
 tSerialBase* tSerialPorts::com_port(void) // uartc or usb
@@ -268,10 +268,10 @@ tDroneCANPort dronecan_port;
 // works here since we only have one serial, and makes the higher level code simpler
 tSerialBase* serial; // assigned according to RxSerPort
 
-typedef struct
+struct tSerialPorts
 {
     void Init(uint8_t serial_port, uint32_t baud);
-} tSerialPorts;
+};
 
 
 void tSerialPorts::Init(uint8_t serial_port, uint32_t baud)

--- a/mLRS/Common/setup_types.h
+++ b/mLRS/Common/setup_types.h
@@ -501,7 +501,7 @@ typedef struct
 
 // global configuration values, not stored in EEPROM
 // can be/are derived from setup parameters, from defines, or otherwise
-typedef struct
+struct tSxGlobalConfig
 {
     uint8_t LoraConfigIndex;
     uint16_t FskSyncWord;
@@ -511,7 +511,7 @@ typedef struct
     // helper
     bool is_lora;
     bool modeIsLora(void) { return is_lora; }
-} tSxGlobalConfig;
+};
 
 
 typedef struct 

--- a/mLRS/CommonTx/disp.h
+++ b/mLRS/CommonTx/disp.h
@@ -125,13 +125,13 @@ class tTxDisp
     void DrawBoot(void);
 
 
-    typedef struct {
+    struct tParamList {
         uint8_t list[SETUP_PARAMETER_NUM];
         uint8_t num;
         uint8_t allowed_num[SETUP_PARAMETER_NUM];
         void clear(void) { num = 0; }
         void add(uint8_t param_idx) { list[num] = param_idx; allowed_num[num] = param_get_allowed_opt_num(param_idx); num++; }
-    } tParamList;
+    };
 
     bool key_has_been_pressed(uint8_t key_idx);
 


### PR DESCRIPTION
A heads up - GCC 16 produces the following warning:

<img width="1055" height="273" alt="image" src="https://github.com/user-attachments/assets/db824d66-a3fc-48c7-9afa-02962f4cb08c" />

This PR only touches the structs that produce the warning as there are many others throughout the code that don't produce the warning.  Unfortunately, this results in inconsistent formats.


